### PR TITLE
RRT* alternative planner

### DIFF
--- a/.github/thirdparty.repos
+++ b/.github/thirdparty.repos
@@ -11,4 +11,7 @@ repositories:
     type: git
     url: https://github.com/kiko2r/navigation2.git
     version: nav2_msgs
-    
+  ThirdParty/yaets:
+    type: git
+    url: https://github.com/fmrico/yaets.git
+    version: rolling

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -30,17 +30,14 @@ jobs:
         with:
           package-name: easynav_gridmap_maps_manager
           target-ros2-distro: rolling
-          vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
-          skip-test: true
           colcon-defaults: |
             {
-              "build": {
-                "packages-up-to": true,
-                  "mixin": ["coverage-gcc"]
+              "test": {
+                "parallel-workers" : 1
               }
             }
+          colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-
       - name: Codecov
         uses: codecov/codecov-action@v5.4.0
         with:

--- a/.github/workflows/rolling.yaml
+++ b/.github/workflows/rolling.yaml
@@ -28,8 +28,9 @@ jobs:
       - name: build and test
         uses: ros-tooling/action-ros-ci@0.4.3
         with:
-          package-name: easynav_gridmap_maps_manager
+          package-name: easynav_gridmap_maps_manager easynav_gridmap_astar_planner easynav_gridmap_rrtstar_planner
           target-ros2-distro: rolling
+          vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/thirdparty.repos
           colcon-defaults: |
             {
               "test": {

--- a/easynav_gridmap_rrtstar_planner/CMakeLists.txt
+++ b/easynav_gridmap_rrtstar_planner/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.20)
+project(easynav_gridmap_rrtstar_planner)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(ament_cmake REQUIRED)
+find_package(easynav_common REQUIRED)
+find_package(easynav_core REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(grid_map_ros REQUIRED)
+find_package(grid_map_msgs REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED
+  src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
+  src/easynav_gridmap_rrtstar_planner/KDTree.cpp
+)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  easynav_common::easynav_common
+  easynav_core::easynav_core
+  pluginlib::pluginlib
+  grid_map_ros::grid_map_ros
+  ${nav_msgs_TARGETS}
+  ${grid_map_msgs_TARGETS}
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+install(TARGETS
+  ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  # add_subdirectory(tests)
+endif()
+
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
+
+# Register the planning plugins
+pluginlib_export_plugin_description_file(easynav_core easynav_gridmap_rrtstar_planner_plugins.xml)
+
+ament_export_dependencies(
+  easynav_common
+  easynav_core
+  easynav_simple_common
+  pluginlib
+  nav_msgs
+  grid_map_ros
+  grid_map_msgs
+)
+ament_package()

--- a/easynav_gridmap_rrtstar_planner/easynav_gridmap_rrtstar_planner_plugins.xml
+++ b/easynav_gridmap_rrtstar_planner/easynav_gridmap_rrtstar_planner_plugins.xml
@@ -1,0 +1,9 @@
+<class_libraries>
+  <library path="easynav_gridmap_rrtstar_planner">
+    <class name="easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner"  type="easynav::GridMapRRTStarPlanner" base_class_type="easynav::PlannerMethodBase">
+      <description>
+      A implementation for the RRT* path planner.
+      </description>
+    </class>
+  </library>
+</class_libraries>

--- a/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.hpp
+++ b/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.hpp
@@ -1,0 +1,222 @@
+// Copyright 2025 Intelligent Robotics Lab
+//
+// This file is part of the project Easy Navigation (EasyNav in short)
+// licensed under the GNU General Public License v3.0.
+// See <http://www.gnu.org/licenses/> for details.
+//
+// Easy Navigation program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+/// \file
+/// \brief Declaration of the GridMapRRTStarPlanner class implementing RRT* path planning using elevation maps.
+
+#ifndef EASYNAV_GRIDMAP_RRTSTAR_PLANNER__GRIDMAPRRTSTARPLANNER_HPP_
+#define EASYNAV_GRIDMAP_RRTSTAR_PLANNER__GRIDMAPRRTSTARPLANNER_HPP_
+
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <algorithm>
+#include <random>
+#include <queue>
+#include <unordered_set>
+#include <unordered_map>
+#include <memory>
+
+#include "grid_map_core/GridMap.hpp"
+#include "nav_msgs/msg/goals.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "easynav_core/PlannerMethodBase.hpp"
+#include "easynav_gridmap_rrtstar_planner/KDTree.hpp"
+#include "easynav_gridmap_rrtstar_planner/RRTNode.hpp"
+#include "tf2/LinearMath/Quaternion.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
+namespace easynav
+{
+
+class KDTree;
+
+    /**
+     * @brief RRT* planner implementation using a grid map with elevation support.
+     *
+     * This planner generates collision-free paths that respect slope constraints.
+     * It includes RRT* optimizations, KD-tree acceleration, and path smoothing.
+     */
+class GridMapRRTStarPlanner : public PlannerMethodBase
+{
+public:
+        /**
+         * @brief Constructor.
+         * Initializes the KD-tree and sets default parameters.
+         */
+  GridMapRRTStarPlanner();
+
+        /**
+         * @brief Initializes the planner plugin.
+         * Declares and retrieves parameters from the ROS2 node.
+         * @return std::expected<void, std::string> Empty if successful, error message if failed.
+         */
+  std::expected<void, std::string> on_initialize() override;
+
+        /**
+         * @brief Main planner update function.
+         * Computes a path from the robot to the goal each cycle.
+         * Publishes the path and visualization markers if there are subscribers.
+         * @param nav_state Navigation state containing robot pose, map, and goals.
+         */
+  void update(NavState & nav_state) override;
+
+protected:
+        /**
+         * @brief Runs RRT* algorithm to generate a path from start to goal.
+         * @param map Grid map used for planning.
+         * @param start Start pose in the map frame.
+         * @param goal Goal pose in the map frame.
+         * @return Vector of smoothed poses representing the planned path.
+         * @note Path will be empty if start or goal is outside map bounds.
+         */
+  std::vector<geometry_msgs::msg::Pose> rrt_star(
+    const grid_map::GridMap & map,
+    const geometry_msgs::msg::Pose & start,
+    const geometry_msgs::msg::Pose & goal);
+
+        /**
+         * @brief Generates a random index inside the map.
+         * @param map Grid map to sample from.
+         * @param rng Random number generator.
+         * @return Random index within map bounds.
+         */
+  grid_map::Index random_index(const grid_map::GridMap & map, std::mt19937 & rng);
+
+        /**
+         * @brief Steers from one index towards another with a maximum step size.
+         * @param map Grid map used for distance conversion.
+         * @param from Starting index.
+         * @param to Target index.
+         * @return New index reached after stepping, or {-1,-1} if outside map.
+         */
+  grid_map::Index steer(
+    const grid_map::GridMap & map, const grid_map::Index & from,
+    const grid_map::Index & to);
+
+        /**
+         * @brief Computes traversal cost between two indices, considering elevation and slope.
+         * @param map Grid map used for cost evaluation.
+         * @param to Destination index.
+         * @param from Source index.
+         * @return Traversal cost. Returns infinity if the path is invalid or slope exceeds max allowed.
+         */
+  double traversal_cost(
+    const grid_map::GridMap & map, const grid_map::Index & to,
+    const grid_map::Index & from);
+
+        /**
+         * @brief Computes Euclidean distance between two indices.
+         * @param map Grid map used to convert indices to positions.
+         * @param a First index.
+         * @param b Second index.
+         * @return Euclidean distance in meters.
+         */
+  double distance(
+    const grid_map::GridMap & map, const grid_map::Index & a,
+    const grid_map::Index & b);
+
+        /**
+         * @brief Extracts path poses from a goal node back to the start node.
+         * @param node Goal node of RRT* tree.
+         * @param map Grid map used for position extraction.
+         * @param goal Goal pose for final orientation.
+         * @return Vector of poses representing the path.
+         */
+  std::vector<geometry_msgs::msg::Pose> extract_path(
+    std::shared_ptr<RRTNode> node,
+    const grid_map::GridMap & map,
+    const geometry_msgs::msg::Pose & goal);
+
+        /**
+         * @brief Finds the nearest node in the tree to a target index.
+         * @param tree Vector of RRT nodes.
+         * @param target Index to find nearest node to.
+         * @param map Grid map used to compute distance.
+         * @return Shared pointer to nearest node, or nullptr if tree is empty.
+         */
+  std::shared_ptr<RRTNode> find_nearest(
+    const std::vector<std::shared_ptr<RRTNode>> & tree,
+    const grid_map::Index & target,
+    const grid_map::GridMap & map);
+
+        /**
+         * @brief Generates a biased sample index for RRT* exploration.
+         * @param map Grid map used for sampling.
+         * @param goal_idx Index of the goal.
+         * @param best_goal_node Best goal node found so far (used for path-biased sampling).
+         * @param rng Random number generator.
+         * @param prob_dist Probability distribution for random sampling.
+         * @return Index sampled for RRT* expansion.
+         */
+  grid_map::Index generate_sample(
+    const grid_map::GridMap & map,
+    const grid_map::Index & goal_idx,
+    std::shared_ptr<RRTNode> best_goal_node,
+    std::mt19937 & rng,
+    std::uniform_real_distribution<double> & prob_dist);
+
+        /**
+         * @brief Smooths a path using Catmull-Rom splines.
+         * @param input_path Input path to smooth.
+         * @param interpolation_points_per_segment Number of interpolated points per segment.
+         * @return Smoothed path as a vector of poses.
+         * @note Spacing between consecutive points is enforced by `spacing_`.
+         */
+  std::vector<geometry_msgs::msg::Pose> smooth_path(
+    const std::vector<geometry_msgs::msg::Pose> & input_path,
+    int interpolation_points_per_segment);
+
+        // -----------------------
+        // Planner parameters
+        // -----------------------
+  double max_allowed_slope_deg_ = 50;                    ///< Maximum slope in degrees
+  double max_allowed_slope_ = 50.0 * M_PI / 180.0;       ///< Maximum slope in radians
+  int max_iters_ = 2000;                                 ///< Maximum RRT* iterations
+  double step_size_ = 0.8;                               ///< Maximum step distance (m)
+  double neighbor_radius_ = 1.5;                         ///< RRT* neighbor radius (m)
+  double goal_bias_ = 0.1;                               ///< Probability of sampling the goal
+  double goal_threshold_ = 1.0;                          ///< Distance threshold for goal connection (m)
+  int kdtree_rebuild_interval_ = 200;                    ///< Interval to rebuild KD-tree
+  double spacing_ = 0.2;                                 ///< Minimum spacing for smoothed path points (m)
+
+        // -----------------------
+        // Runtime state
+        // -----------------------
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr path_pub_;       ///< Path publisher
+  nav_msgs::msg::Path current_path_;                                 ///< Current planned path
+  std::unique_ptr<KDTree> kd_tree_;                                  ///< KD-tree for nearest neighbor search
+  std::unordered_map<uint64_t, double> cost_cache_;                  ///< Cache for traversal costs
+  uint32_t cached_map_width_ = 0;
+  uint32_t cached_map_height_ = 0;
+  uint64_t last_map_timestamp_ = 0;
+
+        // -----------------------
+        // Cache utilities
+        // -----------------------
+  void clear_cost_cache();
+  static uint32_t flat_index(const grid_map::Index & idx, uint32_t width);
+  static uint64_t edge_key(uint32_t a_flat, uint32_t b_flat);
+};
+
+} // namespace easynav
+
+#endif // EASYNAV_GRIDMAP_RRTSTAR_PLANNER__GRIDMAPRRTSTARPLANNER_HPP_

--- a/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.hpp
+++ b/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.hpp
@@ -22,7 +22,6 @@
 
 #ifndef EASYNAV_GRIDMAP_RRTSTAR_PLANNER__GRIDMAPRRTSTARPLANNER_HPP_
 #define EASYNAV_GRIDMAP_RRTSTAR_PLANNER__GRIDMAPRRTSTARPLANNER_HPP_
-
 #include <cmath>
 #include <limits>
 #include <sstream>
@@ -43,130 +42,142 @@
 #include "easynav_gridmap_rrtstar_planner/RRTNode.hpp"
 #include "tf2/LinearMath/Quaternion.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "visualization_msgs/msg/marker.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 namespace easynav
 {
 
 class KDTree;
 
-    /**
-     * @brief RRT* planner implementation using a grid map with elevation support.
-     *
-     * This planner generates collision-free paths that respect slope constraints.
-     * It includes RRT* optimizations, KD-tree acceleration, and path smoothing.
-     */
+/**
+ * @class GridMapRRTStarPlanner
+ * @brief RRT* path planner implementation using elevation grid maps.
+ *
+ * This planner generates collision-free and slope-constrained paths.
+ * Features include:
+ * - RRT* optimization
+ * - KD-tree accelerated nearest neighbor search
+ * - Path smoothing (Catmull-Rom and linear interpolation)
+ * - Visualization markers for debugging and RViz display
+ */
 class GridMapRRTStarPlanner : public PlannerMethodBase
 {
 public:
-        /**
-         * @brief Constructor.
-         * Initializes the KD-tree and sets default parameters.
-         */
+  /**
+   * @brief Constructor. Initializes KD-tree and sets default parameters.
+   */
   GridMapRRTStarPlanner();
 
-        /**
-         * @brief Initializes the planner plugin.
-         * Declares and retrieves parameters from the ROS2 node.
-         * @return std::expected<void, std::string> Empty if successful, error message if failed.
-         */
+  /**
+   * @brief Initializes the planner plugin.
+   *
+   * Declares parameters and sets up internal state.
+   * @return std::expected<void, std::string> Empty if successful, error string otherwise.
+   */
   std::expected<void, std::string> on_initialize() override;
 
-        /**
-         * @brief Main planner update function.
-         * Computes a path from the robot to the goal each cycle.
-         * Publishes the path and visualization markers if there are subscribers.
-         * @param nav_state Navigation state containing robot pose, map, and goals.
-         */
+  /**
+   * @brief Main planner update function.
+   *
+   * Computes a path from the robot to the goal, updates internal state,
+   * and publishes visualization if enabled.
+   *
+   * @param nav_state Navigation state containing robot pose, map, and goals.
+   */
   void update(NavState & nav_state) override;
 
 protected:
-        /**
-         * @brief Runs RRT* algorithm to generate a path from start to goal.
-         * @param map Grid map used for planning.
-         * @param start Start pose in the map frame.
-         * @param goal Goal pose in the map frame.
-         * @return Vector of smoothed poses representing the planned path.
-         * @note Path will be empty if start or goal is outside map bounds.
-         */
+  // ------------------------------------------------------------------
+  // Core RRT* methods
+  // ------------------------------------------------------------------
+
+  /**
+   * @brief Runs the RRT* algorithm to plan a path from start to goal.
+   * @param map Grid map used for planning.
+   * @param start Start pose in map frame.
+   * @param goal Goal pose in map frame.
+   * @return Vector of smoothed poses representing the planned path.
+   *         Empty if start/goal invalid or no path found.
+   */
   std::vector<geometry_msgs::msg::Pose> rrt_star(
     const grid_map::GridMap & map,
     const geometry_msgs::msg::Pose & start,
     const geometry_msgs::msg::Pose & goal);
 
-        /**
-         * @brief Generates a random index inside the map.
-         * @param map Grid map to sample from.
-         * @param rng Random number generator.
-         * @return Random index within map bounds.
-         */
+  /**
+   * @brief Generate a random grid index inside the map bounds.
+   * @param map Grid map to sample from.
+   * @param rng Random number generator.
+   * @return Random index within map bounds.
+   */
   grid_map::Index random_index(const grid_map::GridMap & map, std::mt19937 & rng);
 
-        /**
-         * @brief Steers from one index towards another with a maximum step size.
-         * @param map Grid map used for distance conversion.
-         * @param from Starting index.
-         * @param to Target index.
-         * @return New index reached after stepping, or {-1,-1} if outside map.
-         */
+  /**
+   * @brief Generate a biased random index pointing forward from robot pose.
+   * @param map Grid map.
+   * @param robot_pose Current robot pose.
+   * @param robot_yaw Robot orientation in radians.
+   * @param rng Random generator.
+   * @return Random index biased in forward direction.
+   */
+  grid_map::Index biased_random_index(
+    const grid_map::GridMap & map,
+    const geometry_msgs::msg::Pose & robot_pose,
+    double robot_yaw,
+    std::mt19937 & rng);
+
+  /**
+   * @brief Steer from one index toward another within max step size.
+   * @param map Grid map.
+   * @param from Starting index.
+   * @param to Target index.
+   * @return New index reached after stepping, or {-1,-1} if outside map.
+   */
   grid_map::Index steer(
-    const grid_map::GridMap & map, const grid_map::Index & from,
+    const grid_map::GridMap & map,
+    const grid_map::Index & from,
     const grid_map::Index & to);
 
-        /**
-         * @brief Computes traversal cost between two indices, considering elevation and slope.
-         * @param map Grid map used for cost evaluation.
-         * @param to Destination index.
-         * @param from Source index.
-         * @return Traversal cost. Returns infinity if the path is invalid or slope exceeds max allowed.
-         */
+  /**
+   * @brief Compute traversal cost between two indices.
+   *
+   * Considers elevation changes and slope constraints.
+   *
+   * @param map Grid map.
+   * @param from Source index.
+   * @param to Destination index.
+   * @return Traversal cost, or infinity if slope exceeds max.
+   */
   double traversal_cost(
-    const grid_map::GridMap & map, const grid_map::Index & to,
-    const grid_map::Index & from);
+    const grid_map::GridMap & map,
+    const grid_map::Index & from,
+    const grid_map::Index & to);
 
-        /**
-         * @brief Computes Euclidean distance between two indices.
-         * @param map Grid map used to convert indices to positions.
-         * @param a First index.
-         * @param b Second index.
-         * @return Euclidean distance in meters.
-         */
+  /**
+   * @brief Compute Euclidean distance between two map indices.
+   * @param map Grid map.
+   * @param a First index.
+   * @param b Second index.
+   * @return Distance in meters.
+   */
   double distance(
-    const grid_map::GridMap & map, const grid_map::Index & a,
+    const grid_map::GridMap & map,
+    const grid_map::Index & a,
     const grid_map::Index & b);
 
-        /**
-         * @brief Extracts path poses from a goal node back to the start node.
-         * @param node Goal node of RRT* tree.
-         * @param map Grid map used for position extraction.
-         * @param goal Goal pose for final orientation.
-         * @return Vector of poses representing the path.
-         */
-  std::vector<geometry_msgs::msg::Pose> extract_path(
-    std::shared_ptr<RRTNode> node,
-    const grid_map::GridMap & map,
-    const geometry_msgs::msg::Pose & goal);
-
-        /**
-         * @brief Finds the nearest node in the tree to a target index.
-         * @param tree Vector of RRT nodes.
-         * @param target Index to find nearest node to.
-         * @param map Grid map used to compute distance.
-         * @return Shared pointer to nearest node, or nullptr if tree is empty.
-         */
-  std::shared_ptr<RRTNode> find_nearest(
-    const std::vector<std::shared_ptr<RRTNode>> & tree,
-    const grid_map::Index & target,
-    const grid_map::GridMap & map);
-
-        /**
-         * @brief Generates a biased sample index for RRT* exploration.
-         * @param map Grid map used for sampling.
-         * @param goal_idx Index of the goal.
-         * @param best_goal_node Best goal node found so far (used for path-biased sampling).
-         * @param rng Random number generator.
-         * @param prob_dist Probability distribution for random sampling.
-         * @return Index sampled for RRT* expansion.
-         */
+  /**
+   * @brief Generate a sample index for RRT* expansion.
+   *
+   * Sampling may be goal-biased, path-biased, or uniform random.
+   *
+   * @param map Grid map.
+   * @param goal_idx Goal index.
+   * @param best_goal_node Current best goal node.
+   * @param rng Random generator.
+   * @param prob_dist Probability distribution.
+   * @return Sampled grid index.
+   */
   grid_map::Index generate_sample(
     const grid_map::GridMap & map,
     const grid_map::Index & goal_idx,
@@ -174,46 +185,163 @@ protected:
     std::mt19937 & rng,
     std::uniform_real_distribution<double> & prob_dist);
 
-        /**
-         * @brief Smooths a path using Catmull-Rom splines.
-         * @param input_path Input path to smooth.
-         * @param interpolation_points_per_segment Number of interpolated points per segment.
-         * @return Smoothed path as a vector of poses.
-         * @note Spacing between consecutive points is enforced by `spacing_`.
-         */
+  /**
+   * @brief Find the nearest node in the tree to a target index.
+   * @param tree RRT* tree of nodes.
+   * @param target Target index.
+   * @param map Grid map.
+   * @return Shared pointer to nearest node, or nullptr if empty.
+   */
+  std::shared_ptr<RRTNode> find_nearest(
+    const std::vector<std::shared_ptr<RRTNode>> & tree,
+    const grid_map::Index & target,
+    const grid_map::GridMap & map);
+
+  /**
+   * @brief Backtrack from goal node to extract the full path.
+   * @param goal Goal node in the tree.
+   * @param map Grid map.
+   * @param goal_pose Final goal pose (orientation).
+   * @return Vector of poses representing path.
+   */
+  std::vector<geometry_msgs::msg::Pose> extract_path(
+    std::shared_ptr<RRTNode> goal,
+    const grid_map::GridMap & map,
+    const geometry_msgs::msg::Pose & goal_pose);
+
+  // ------------------------------------------------------------------
+  // Path management and smoothing
+  // ------------------------------------------------------------------
+
+  /**
+   * @brief Merge new path poses with stored path and publish results.
+   * @param new_poses Vector of new poses.
+   * @param frame_id Map frame ID.
+   */
+  void combine_paths(
+    const std::vector<geometry_msgs::msg::Pose> & new_poses,
+    const std::string & frame_id);
+
+  /**
+   * @brief Generate a new path given robot and goal poses.
+   * @param map Grid map.
+   * @param robot_pose Current robot pose.
+   * @param goal_pose Target goal pose.
+   * @return Vector of poses forming a path.
+   */
+  std::vector<geometry_msgs::msg::Pose> generate_new_path(
+    const grid_map::GridMap & map,
+    const geometry_msgs::msg::Pose & robot_pose,
+    const geometry_msgs::msg::Pose & goal_pose);
+
+  /**
+   * @brief Publish path visualization markers for RViz.
+   * @param path Path message.
+   */
+  void publish_path_markers(const nav_msgs::msg::Path & path);
+
+  /**
+   * @brief Smooth path using Catmull-Rom splines.
+   * @param input_path Original path.
+   * @param interpolation_points_per_segment Number of interpolated points.
+   * @return Smoothed path.
+   */
   std::vector<geometry_msgs::msg::Pose> smooth_path(
     const std::vector<geometry_msgs::msg::Pose> & input_path,
     int interpolation_points_per_segment);
 
-        // -----------------------
-        // Planner parameters
-        // -----------------------
-  double max_allowed_slope_deg_ = 50;                    ///< Maximum slope in degrees
-  double max_allowed_slope_ = 50.0 * M_PI / 180.0;       ///< Maximum slope in radians
-  int max_iters_ = 2000;                                 ///< Maximum RRT* iterations
-  double step_size_ = 0.8;                               ///< Maximum step distance (m)
-  double neighbor_radius_ = 1.5;                         ///< RRT* neighbor radius (m)
-  double goal_bias_ = 0.1;                               ///< Probability of sampling the goal
-  double goal_threshold_ = 1.0;                          ///< Distance threshold for goal connection (m)
-  int kdtree_rebuild_interval_ = 200;                    ///< Interval to rebuild KD-tree
-  double spacing_ = 0.2;                                 ///< Minimum spacing for smoothed path points (m)
+  /**
+   * @brief Linearly interpolate between path points.
+   * @param input_path Original path.
+   * @param interpolation_points_per_segment Points per segment.
+   * @return Interpolated path.
+   */
+  std::vector<geometry_msgs::msg::Pose> linear_interpolate_path(
+    const std::vector<geometry_msgs::msg::Pose> & input_path,
+    int interpolation_points_per_segment);
 
-        // -----------------------
-        // Runtime state
-        // -----------------------
-  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr path_pub_;       ///< Path publisher
-  nav_msgs::msg::Path current_path_;                                 ///< Current planned path
-  std::unique_ptr<KDTree> kd_tree_;                                  ///< KD-tree for nearest neighbor search
-  std::unordered_map<uint64_t, double> cost_cache_;                  ///< Cache for traversal costs
-  uint32_t cached_map_width_ = 0;
-  uint32_t cached_map_height_ = 0;
-  uint64_t last_map_timestamp_ = 0;
+  /**
+   * @brief Trim path to start from current robot pose.
+   * @param path Original path.
+   * @param robot_pose Current robot pose.
+   * @return Trimmed path message.
+   */
+  nav_msgs::msg::Path trim_path_from_robot(
+    const nav_msgs::msg::Path & path,
+    const geometry_msgs::msg::Pose & robot_pose) const;
 
-        // -----------------------
-        // Cache utilities
-        // -----------------------
+  /**
+   * @brief Check if the goal has changed significantly since last update.
+   * @param goal_pose New goal pose.
+   * @return True if changed, false otherwise.
+   */
+  bool check_goal_changed(const geometry_msgs::msg::Pose & goal_pose);
+
+  /**
+   * @brief Compute lateral deviation of robot pose from a path.
+   * @param path Path.
+   * @param robot_pose Current pose.
+   * @return Lateral deviation distance.
+   */
+  double calculate_lateral_distance_to_path(
+    const nav_msgs::msg::Path & path,
+    const geometry_msgs::msg::Pose & robot_pose) const;
+
+  // ------------------------------------------------------------------
+  // Parameters
+  // ------------------------------------------------------------------
+  double max_allowed_slope_deg_ = 50;              ///< Maximum slope in degrees
+  double max_allowed_slope_ = 50.0 * M_PI / 180.0; ///< Maximum slope in radians
+  int max_iters_ = 2000;                           ///< Maximum RRT* iterations
+  double step_size_ = 0.8;                         ///< Step size in meters
+  double neighbor_radius_ = 1.5;                   ///< Neighbor radius in meters
+  double goal_bias_ = 0.1;                         ///< Probability of sampling goal
+  double goal_threshold_ = 1.0;                    ///< Goal connection threshold (m)
+  int kdtree_rebuild_interval_ = 200;              ///< KD-tree rebuild interval
+  double spacing_ = 0.2;                           ///< Min spacing for smoothed path points
+  double max_lateral_deviation_ = 1.5;             ///< Allowed lateral deviation (m)
+  int final_poses_with_goal_orientation_ = 2;      ///< Preserve orientation for last poses
+
+  // ------------------------------------------------------------------
+  // Runtime state
+  // ------------------------------------------------------------------
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr path_pub_;       ///< Publisher for path
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_; ///< Publisher for markers
+  nav_msgs::msg::Path current_path_;                                ///< Current stored path
+  std::unique_ptr<KDTree> kd_tree_;                                 ///< KD-tree for NN search
+  std::unordered_map<uint64_t, double> cost_cache_;                 ///< Traversal cost cache
+  uint32_t cached_map_width_ = 0;                                   ///< Cached map width
+  uint32_t cached_map_height_ = 0;                                  ///< Cached map height
+  uint64_t last_map_timestamp_ = 0;                                 ///< Cached map timestamp
+  double last_path_cost_ = 0.0;                                     ///< Cost of previous path
+  double current_path_cost_ = std::numeric_limits<double>::max();    ///< Cost of current path
+  double new_path_cost_ = std::numeric_limits<double>::max();        ///< Cost of new candidate path
+  int kdtree_rebuild_counter_ = 0;                                  ///< Counter for KD-tree rebuilds
+  geometry_msgs::msg::Pose last_goal_pose_;                         ///< Last processed goal pose
+
+  // ------------------------------------------------------------------
+  // Cache utilities
+  // ------------------------------------------------------------------
+
+  /**
+   * @brief Clear traversal cost cache.
+   */
   void clear_cost_cache();
+
+  /**
+   * @brief Compute flat index from 2D index.
+   * @param idx Grid index.
+   * @param width Map width.
+   * @return Flat index.
+   */
   static uint32_t flat_index(const grid_map::Index & idx, uint32_t width);
+
+  /**
+   * @brief Generate unique key for an edge between two nodes.
+   * @param a_flat Flat index of first node.
+   * @param b_flat Flat index of second node.
+   * @return Unique edge key.
+   */
   static uint64_t edge_key(uint32_t a_flat, uint32_t b_flat);
 };
 

--- a/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.hpp
+++ b/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.hpp
@@ -64,120 +64,120 @@ class KDTree;
 class GridMapRRTStarPlanner : public PlannerMethodBase
 {
 public:
-  /**
-   * @brief Constructor. Initializes KD-tree and sets default parameters.
-   */
+/**
+ * @brief Constructor. Initializes KD-tree and sets default parameters.
+ */
   GridMapRRTStarPlanner();
 
-  /**
-   * @brief Initializes the planner plugin.
-   *
-   * Declares parameters and sets up internal state.
-   * @return std::expected<void, std::string> Empty if successful, error string otherwise.
-   */
+/**
+ * @brief Initializes the planner plugin.
+ *
+ * Declares parameters and sets up internal state.
+ * @return std::expected<void, std::string> Empty if successful, error string otherwise.
+ */
   std::expected<void, std::string> on_initialize() override;
 
-  /**
-   * @brief Main planner update function.
-   *
-   * Computes a path from the robot to the goal, updates internal state,
-   * and publishes visualization if enabled.
-   *
-   * @param nav_state Navigation state containing robot pose, map, and goals.
-   */
+/**
+ * @brief Main planner update function.
+ *
+ * Computes a path from the robot to the goal, updates internal state,
+ * and publishes visualization if enabled.
+ *
+ * @param nav_state Navigation state containing robot pose, map, and goals.
+ */
   void update(NavState & nav_state) override;
 
 protected:
-  // ------------------------------------------------------------------
-  // Core RRT* methods
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Core RRT* methods
+// ------------------------------------------------------------------
 
-  /**
-   * @brief Runs the RRT* algorithm to plan a path from start to goal.
-   * @param map Grid map used for planning.
-   * @param start Start pose in map frame.
-   * @param goal Goal pose in map frame.
-   * @return Vector of smoothed poses representing the planned path.
-   *         Empty if start/goal invalid or no path found.
-   */
+/**
+ * @brief Runs the RRT* algorithm to plan a path from start to goal.
+ * @param map Grid map used for planning.
+ * @param start Start pose in map frame.
+ * @param goal Goal pose in map frame.
+ * @return Vector of smoothed poses representing the planned path.
+ *         Empty if start/goal invalid or no path found.
+ */
   std::vector<geometry_msgs::msg::Pose> rrt_star(
     const grid_map::GridMap & map,
     const geometry_msgs::msg::Pose & start,
     const geometry_msgs::msg::Pose & goal);
 
-  /**
-   * @brief Generate a random grid index inside the map bounds.
-   * @param map Grid map to sample from.
-   * @param rng Random number generator.
-   * @return Random index within map bounds.
-   */
+/**
+ * @brief Generate a random grid index inside the map bounds.
+ * @param map Grid map to sample from.
+ * @param rng Random number generator.
+ * @return Random index within map bounds.
+ */
   grid_map::Index random_index(const grid_map::GridMap & map, std::mt19937 & rng);
 
-  /**
-   * @brief Generate a biased random index pointing forward from robot pose.
-   * @param map Grid map.
-   * @param robot_pose Current robot pose.
-   * @param robot_yaw Robot orientation in radians.
-   * @param rng Random generator.
-   * @return Random index biased in forward direction.
-   */
+/**
+ * @brief Generate a biased random index pointing forward from robot pose.
+ * @param map Grid map.
+ * @param robot_pose Current robot pose.
+ * @param robot_yaw Robot orientation in radians.
+ * @param rng Random generator.
+ * @return Random index biased in forward direction.
+ */
   grid_map::Index biased_random_index(
     const grid_map::GridMap & map,
     const geometry_msgs::msg::Pose & robot_pose,
     double robot_yaw,
     std::mt19937 & rng);
 
-  /**
-   * @brief Steer from one index toward another within max step size.
-   * @param map Grid map.
-   * @param from Starting index.
-   * @param to Target index.
-   * @return New index reached after stepping, or {-1,-1} if outside map.
-   */
+/**
+ * @brief Steer from one index toward another within max step size.
+ * @param map Grid map.
+ * @param from Starting index.
+ * @param to Target index.
+ * @return New index reached after stepping, or {-1,-1} if outside map.
+ */
   grid_map::Index steer(
     const grid_map::GridMap & map,
     const grid_map::Index & from,
     const grid_map::Index & to);
 
-  /**
-   * @brief Compute traversal cost between two indices.
-   *
-   * Considers elevation changes and slope constraints.
-   *
-   * @param map Grid map.
-   * @param from Source index.
-   * @param to Destination index.
-   * @return Traversal cost, or infinity if slope exceeds max.
-   */
+/**
+ * @brief Compute traversal cost between two indices.
+ *
+ * Considers elevation changes and slope constraints.
+ *
+ * @param map Grid map.
+ * @param from Source index.
+ * @param to Destination index.
+ * @return Traversal cost, or infinity if slope exceeds max.
+ */
   double traversal_cost(
     const grid_map::GridMap & map,
     const grid_map::Index & from,
     const grid_map::Index & to);
 
-  /**
-   * @brief Compute Euclidean distance between two map indices.
-   * @param map Grid map.
-   * @param a First index.
-   * @param b Second index.
-   * @return Distance in meters.
-   */
+/**
+ * @brief Compute Euclidean distance between two map indices.
+ * @param map Grid map.
+ * @param a First index.
+ * @param b Second index.
+ * @return Distance in meters.
+ */
   double distance(
     const grid_map::GridMap & map,
     const grid_map::Index & a,
     const grid_map::Index & b);
 
-  /**
-   * @brief Generate a sample index for RRT* expansion.
-   *
-   * Sampling may be goal-biased, path-biased, or uniform random.
-   *
-   * @param map Grid map.
-   * @param goal_idx Goal index.
-   * @param best_goal_node Current best goal node.
-   * @param rng Random generator.
-   * @param prob_dist Probability distribution.
-   * @return Sampled grid index.
-   */
+/**
+ * @brief Generate a sample index for RRT* expansion.
+ *
+ * Sampling may be goal-biased, path-biased, or uniform random.
+ *
+ * @param map Grid map.
+ * @param goal_idx Goal index.
+ * @param best_goal_node Current best goal node.
+ * @param rng Random generator.
+ * @param prob_dist Probability distribution.
+ * @return Sampled grid index.
+ */
   grid_map::Index generate_sample(
     const grid_map::GridMap & map,
     const grid_map::Index & goal_idx,
@@ -185,111 +185,111 @@ protected:
     std::mt19937 & rng,
     std::uniform_real_distribution<double> & prob_dist);
 
-  /**
-   * @brief Find the nearest node in the tree to a target index.
-   * @param tree RRT* tree of nodes.
-   * @param target Target index.
-   * @param map Grid map.
-   * @return Shared pointer to nearest node, or nullptr if empty.
-   */
+/**
+ * @brief Find the nearest node in the tree to a target index.
+ * @param tree RRT* tree of nodes.
+ * @param target Target index.
+ * @param map Grid map.
+ * @return Shared pointer to nearest node, or nullptr if empty.
+ */
   std::shared_ptr<RRTNode> find_nearest(
     const std::vector<std::shared_ptr<RRTNode>> & tree,
     const grid_map::Index & target,
     const grid_map::GridMap & map);
 
-  /**
-   * @brief Backtrack from goal node to extract the full path.
-   * @param goal Goal node in the tree.
-   * @param map Grid map.
-   * @param goal_pose Final goal pose (orientation).
-   * @return Vector of poses representing path.
-   */
+/**
+ * @brief Backtrack from goal node to extract the full path.
+ * @param goal Goal node in the tree.
+ * @param map Grid map.
+ * @param goal_pose Final goal pose (orientation).
+ * @return Vector of poses representing path.
+ */
   std::vector<geometry_msgs::msg::Pose> extract_path(
     std::shared_ptr<RRTNode> goal,
     const grid_map::GridMap & map,
     const geometry_msgs::msg::Pose & goal_pose);
 
-  // ------------------------------------------------------------------
-  // Path management and smoothing
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Path management and smoothing
+// ------------------------------------------------------------------
 
-  /**
-   * @brief Merge new path poses with stored path and publish results.
-   * @param new_poses Vector of new poses.
-   * @param frame_id Map frame ID.
-   */
+/**
+ * @brief Merge new path poses with stored path and publish results.
+ * @param new_poses Vector of new poses.
+ * @param frame_id Map frame ID.
+ */
   void combine_paths(
     const std::vector<geometry_msgs::msg::Pose> & new_poses,
     const std::string & frame_id);
 
-  /**
-   * @brief Generate a new path given robot and goal poses.
-   * @param map Grid map.
-   * @param robot_pose Current robot pose.
-   * @param goal_pose Target goal pose.
-   * @return Vector of poses forming a path.
-   */
+/**
+ * @brief Generate a new path given robot and goal poses.
+ * @param map Grid map.
+ * @param robot_pose Current robot pose.
+ * @param goal_pose Target goal pose.
+ * @return Vector of poses forming a path.
+ */
   std::vector<geometry_msgs::msg::Pose> generate_new_path(
     const grid_map::GridMap & map,
     const geometry_msgs::msg::Pose & robot_pose,
     const geometry_msgs::msg::Pose & goal_pose);
 
-  /**
-   * @brief Publish path visualization markers for RViz.
-   * @param path Path message.
-   */
+/**
+ * @brief Publish path visualization markers for RViz.
+ * @param path Path message.
+ */
   void publish_path_markers(const nav_msgs::msg::Path & path);
 
-  /**
-   * @brief Smooth path using Catmull-Rom splines.
-   * @param input_path Original path.
-   * @param interpolation_points_per_segment Number of interpolated points.
-   * @return Smoothed path.
-   */
+/**
+ * @brief Smooth path using Catmull-Rom splines.
+ * @param input_path Original path.
+ * @param interpolation_points_per_segment Number of interpolated points.
+ * @return Smoothed path.
+ */
   std::vector<geometry_msgs::msg::Pose> smooth_path(
     const std::vector<geometry_msgs::msg::Pose> & input_path,
     int interpolation_points_per_segment);
 
-  /**
-   * @brief Linearly interpolate between path points.
-   * @param input_path Original path.
-   * @param interpolation_points_per_segment Points per segment.
-   * @return Interpolated path.
-   */
+/**
+ * @brief Linearly interpolate between path points.
+ * @param input_path Original path.
+ * @param interpolation_points_per_segment Points per segment.
+ * @return Interpolated path.
+ */
   std::vector<geometry_msgs::msg::Pose> linear_interpolate_path(
     const std::vector<geometry_msgs::msg::Pose> & input_path,
     int interpolation_points_per_segment);
 
-  /**
-   * @brief Trim path to start from current robot pose.
-   * @param path Original path.
-   * @param robot_pose Current robot pose.
-   * @return Trimmed path message.
-   */
+/**
+ * @brief Trim path to start from current robot pose.
+ * @param path Original path.
+ * @param robot_pose Current robot pose.
+ * @return Trimmed path message.
+ */
   nav_msgs::msg::Path trim_path_from_robot(
     const nav_msgs::msg::Path & path,
     const geometry_msgs::msg::Pose & robot_pose) const;
 
-  /**
-   * @brief Check if the goal has changed significantly since last update.
-   * @param goal_pose New goal pose.
-   * @return True if changed, false otherwise.
-   */
+/**
+ * @brief Check if the goal has changed significantly since last update.
+ * @param goal_pose New goal pose.
+ * @return True if changed, false otherwise.
+ */
   bool check_goal_changed(const geometry_msgs::msg::Pose & goal_pose);
 
-  /**
-   * @brief Compute lateral deviation of robot pose from a path.
-   * @param path Path.
-   * @param robot_pose Current pose.
-   * @return Lateral deviation distance.
-   */
+/**
+ * @brief Compute lateral deviation of robot pose from a path.
+ * @param path Path.
+ * @param robot_pose Current pose.
+ * @return Lateral deviation distance.
+ */
   double calculate_lateral_distance_to_path(
     const nav_msgs::msg::Path & path,
     const geometry_msgs::msg::Pose & robot_pose) const;
 
-  // ------------------------------------------------------------------
-  // Parameters
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Parameters
+// ------------------------------------------------------------------
   double max_allowed_slope_deg_ = 50;              ///< Maximum slope in degrees
   double max_allowed_slope_ = 50.0 * M_PI / 180.0; ///< Maximum slope in radians
   int max_iters_ = 2000;                           ///< Maximum RRT* iterations
@@ -302,9 +302,9 @@ protected:
   double max_lateral_deviation_ = 1.5;             ///< Allowed lateral deviation (m)
   int final_poses_with_goal_orientation_ = 2;      ///< Preserve orientation for last poses
 
-  // ------------------------------------------------------------------
-  // Runtime state
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Runtime state
+// ------------------------------------------------------------------
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr path_pub_;       ///< Publisher for path
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_; ///< Publisher for markers
   nav_msgs::msg::Path current_path_;                                ///< Current stored path
@@ -319,29 +319,29 @@ protected:
   int kdtree_rebuild_counter_ = 0;                                  ///< Counter for KD-tree rebuilds
   geometry_msgs::msg::Pose last_goal_pose_;                         ///< Last processed goal pose
 
-  // ------------------------------------------------------------------
-  // Cache utilities
-  // ------------------------------------------------------------------
+// ------------------------------------------------------------------
+// Cache utilities
+// ------------------------------------------------------------------
 
-  /**
-   * @brief Clear traversal cost cache.
-   */
+/**
+ * @brief Clear traversal cost cache.
+ */
   void clear_cost_cache();
 
-  /**
-   * @brief Compute flat index from 2D index.
-   * @param idx Grid index.
-   * @param width Map width.
-   * @return Flat index.
-   */
+/**
+ * @brief Compute flat index from 2D index.
+ * @param idx Grid index.
+ * @param width Map width.
+ * @return Flat index.
+ */
   static uint32_t flat_index(const grid_map::Index & idx, uint32_t width);
 
-  /**
-   * @brief Generate unique key for an edge between two nodes.
-   * @param a_flat Flat index of first node.
-   * @param b_flat Flat index of second node.
-   * @return Unique edge key.
-   */
+/**
+ * @brief Generate unique key for an edge between two nodes.
+ * @param a_flat Flat index of first node.
+ * @param b_flat Flat index of second node.
+ * @return Unique edge key.
+ */
   static uint64_t edge_key(uint32_t a_flat, uint32_t b_flat);
 };
 

--- a/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/KDTree.hpp
+++ b/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/KDTree.hpp
@@ -41,9 +41,9 @@ struct RRTNode;
  */
 class KDTree {
 private:
-    /**
-     * @brief Internal node of the KD-tree.
-     */
+/**
+ * @brief Internal node of the KD-tree.
+ */
   struct KDNode
   {
     std::shared_ptr<RRTNode> rrt_node;     ///< Associated RRT node
@@ -51,49 +51,51 @@ private:
     std::unique_ptr<KDNode> right;          ///< Right subtree
     int depth;                               ///< Depth of this node in the tree
 
-        /**
-         * @brief KDNode constructor
-         * @param node Pointer to associated RRTNode
-         * @param d Depth in the KD-tree
-         */
+  /**
+   * @brief KDNode constructor
+   * @param node Pointer to associated RRTNode
+   * @param d Depth in the KD-tree
+   */
     KDNode(std::shared_ptr<RRTNode> node, int d)
-    : rrt_node(node), depth(d) {}
+    : rrt_node(node), depth(d)
+    {
+    }
   };
 
   std::unique_ptr<KDNode> root;   ///< Root of the KD-tree
 
-    /**
-     * @brief Recursively builds a balanced KD-tree from a list of nodes.
-     * @param nodes List of RRT nodes to include in the tree
-     * @param depth Current depth (used to determine split axis)
-     * @return Unique pointer to the root KDNode of the subtree
-     */
+/**
+ * @brief Recursively builds a balanced KD-tree from a list of nodes.
+ * @param nodes List of RRT nodes to include in the tree
+ * @param depth Current depth (used to determine split axis)
+ * @return Unique pointer to the root KDNode of the subtree
+ */
   std::unique_ptr<KDNode> build(std::vector<std::shared_ptr<RRTNode>> & nodes, int depth);
 
-    /**
-     * @brief Recursively searches the KD-tree for nodes within a given squared radius.
-     * @param node Current subtree node
-     * @param target Index to search neighbors around
-     * @param radius_sq Squared radius for neighbor search
-     * @param result Vector to store found neighbor nodes
-     */
+/**
+ * @brief Recursively searches the KD-tree for nodes within a given squared radius.
+ * @param node Current subtree node
+ * @param target Index to search neighbors around
+ * @param radius_sq Squared radius for neighbor search
+ * @param result Vector to store found neighbor nodes
+ */
   void search_radius(
     const std::unique_ptr<KDNode> & node, const grid_map::Index & target,
     double radius_sq, std::vector<std::shared_ptr<RRTNode>> & result);
 
 public:
-    /**
-     * @brief Rebuilds the KD-tree from a given set of RRT nodes.
-     * @param nodes Vector of RRT nodes to include
-     */
+/**
+ * @brief Rebuilds the KD-tree from a given set of RRT nodes.
+ * @param nodes Vector of RRT nodes to include
+ */
   void rebuild(std::vector<std::shared_ptr<RRTNode>> & nodes);
 
-    /**
-     * @brief Finds all RRT nodes within a given radius of a target index.
-     * @param index Target index for neighbor search
-     * @param radius Search radius in map units
-     * @return Vector of shared pointers to RRT nodes within the radius
-     */
+/**
+ * @brief Finds all RRT nodes within a given radius of a target index.
+ * @param index Target index for neighbor search
+ * @param radius Search radius in map units
+ * @return Vector of shared pointers to RRT nodes within the radius
+ */
   std::vector<std::shared_ptr<RRTNode>> find_neighbors(
     const grid_map::Index & index,
     double radius);

--- a/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/KDTree.hpp
+++ b/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/KDTree.hpp
@@ -1,0 +1,104 @@
+// Copyright 2025 Intelligent Robotics Lab
+//
+// This file is part of the project Easy Navigation (EasyNav in short)
+// licensed under the GNU General Public License v3.0.
+// See <http://www.gnu.org/licenses/> for details.
+//
+// Easy Navigation program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+/// \file
+/// \brief Declaration of the KDTree class for efficient nearest neighbor search of RRT nodes.
+#ifndef EASYNAV_GRIDMAP_RRTSTAR_PLANNER__KDTREE_HPP_
+#define EASYNAV_GRIDMAP_RRTSTAR_PLANNER__KDTREE_HPP_
+
+#include <vector>
+#include <memory>
+#include <algorithm>
+#include "grid_map_core/GridMap.hpp"
+#include "easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.hpp"
+#include "easynav_gridmap_rrtstar_planner/RRTNode.hpp"
+
+namespace easynav
+{
+
+struct RRTNode;
+
+/**
+ * @brief KD-tree for efficient nearest neighbor search of RRT nodes in a grid map.
+ *
+ * Supports incremental rebuilding and radius-based neighbor queries.
+ */
+class KDTree {
+private:
+    /**
+     * @brief Internal node of the KD-tree.
+     */
+  struct KDNode
+  {
+    std::shared_ptr<RRTNode> rrt_node;     ///< Associated RRT node
+    std::unique_ptr<KDNode> left;           ///< Left subtree
+    std::unique_ptr<KDNode> right;          ///< Right subtree
+    int depth;                               ///< Depth of this node in the tree
+
+        /**
+         * @brief KDNode constructor
+         * @param node Pointer to associated RRTNode
+         * @param d Depth in the KD-tree
+         */
+    KDNode(std::shared_ptr<RRTNode> node, int d)
+    : rrt_node(node), depth(d) {}
+  };
+
+  std::unique_ptr<KDNode> root;   ///< Root of the KD-tree
+
+    /**
+     * @brief Recursively builds a balanced KD-tree from a list of nodes.
+     * @param nodes List of RRT nodes to include in the tree
+     * @param depth Current depth (used to determine split axis)
+     * @return Unique pointer to the root KDNode of the subtree
+     */
+  std::unique_ptr<KDNode> build(std::vector<std::shared_ptr<RRTNode>> & nodes, int depth);
+
+    /**
+     * @brief Recursively searches the KD-tree for nodes within a given squared radius.
+     * @param node Current subtree node
+     * @param target Index to search neighbors around
+     * @param radius_sq Squared radius for neighbor search
+     * @param result Vector to store found neighbor nodes
+     */
+  void search_radius(
+    const std::unique_ptr<KDNode> & node, const grid_map::Index & target,
+    double radius_sq, std::vector<std::shared_ptr<RRTNode>> & result);
+
+public:
+    /**
+     * @brief Rebuilds the KD-tree from a given set of RRT nodes.
+     * @param nodes Vector of RRT nodes to include
+     */
+  void rebuild(std::vector<std::shared_ptr<RRTNode>> & nodes);
+
+    /**
+     * @brief Finds all RRT nodes within a given radius of a target index.
+     * @param index Target index for neighbor search
+     * @param radius Search radius in map units
+     * @return Vector of shared pointers to RRT nodes within the radius
+     */
+  std::vector<std::shared_ptr<RRTNode>> find_neighbors(
+    const grid_map::Index & index,
+    double radius);
+};
+
+} // namespace easynav
+
+#endif  // EASYNAV_GRIDMAP_RRTSTAR_PLANNER__KDTREE_HPP_

--- a/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/RRTNode.hpp
+++ b/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/RRTNode.hpp
@@ -42,26 +42,26 @@ struct RRTNode
   std::shared_ptr<RRTNode> parent = nullptr;         ///< Pointer to parent node in the tree
   double cost = 0.0;                                 ///< Accumulated cost from root
 
-    /// @brief Default constructor
+  /// @brief Default constructor
   RRTNode() = default;
 
-    /**
-     * @brief Construct node with specific index and optional cost
-     * @param idx Grid cell index
-     * @param c Initial cost (default 0.0)
-     */
+  /**
+   * @brief Construct node with specific index and optional cost
+   * @param idx Grid cell index
+   * @param c Initial cost (default 0.0)
+   */
   explicit RRTNode(const grid_map::Index & idx, double c = 0.0)
   : index(idx), cost(c)
   {
   }
 
-    /**
-     * @brief Change parent of this node and update cumulative cost
-     * @param new_parent New parent node
-     * @param new_cost Updated cumulative cost
-     *
-     * Note: children list is not automatically updated for performance reasons.
-     */
+  /**
+   * @brief Change parent of this node and update cumulative cost
+   * @param new_parent New parent node
+   * @param new_cost Updated cumulative cost
+   *
+   * Note: children list is not automatically updated for performance reasons.
+   */
   void change_parent(std::shared_ptr<RRTNode> new_parent, double new_cost)
   {
     parent = new_parent;

--- a/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/RRTNode.hpp
+++ b/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/RRTNode.hpp
@@ -40,7 +40,6 @@ struct RRTNode
 {
   grid_map::Index index;                             ///< Grid cell index (x, y)
   std::shared_ptr<RRTNode> parent = nullptr;         ///< Pointer to parent node in the tree
-  std::vector<std::shared_ptr<RRTNode>> children;    ///< Pointers to child nodes
   double cost = 0.0;                                 ///< Accumulated cost from root
 
     /// @brief Default constructor

--- a/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/RRTNode.hpp
+++ b/easynav_gridmap_rrtstar_planner/include/easynav_gridmap_rrtstar_planner/RRTNode.hpp
@@ -1,0 +1,75 @@
+// Copyright 2025 Intelligent Robotics Lab
+//
+// This file is part of the project Easy Navigation (EasyNav in short)
+// licensed under the GNU General Public License v3.0.
+// See <http://www.gnu.org/licenses/> for details.
+//
+// Easy Navigation program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+/// \file
+/// \brief Declaration of the RRTNode structure which represents a single node in the RRT* tree.
+
+#ifndef EASYNAV_GRIDMAP_RRTSTAR_PLANNER__RRTNODE_HPP_
+#define EASYNAV_GRIDMAP_RRTSTAR_PLANNER__RRTNODE_HPP_
+
+#include <memory>
+#include <vector>
+#include "grid_map_core/GridMap.hpp"
+
+namespace easynav
+{
+
+/**
+ * @brief Represents a node in the RRT* tree.
+ *
+ * Stores the grid map index, parent and children pointers, and cumulative cost
+ * from the root. Used by the KDTree and RRT* planner for path generation.
+ */
+struct RRTNode
+{
+  grid_map::Index index;                             ///< Grid cell index (x, y)
+  std::shared_ptr<RRTNode> parent = nullptr;         ///< Pointer to parent node in the tree
+  std::vector<std::shared_ptr<RRTNode>> children;    ///< Pointers to child nodes
+  double cost = 0.0;                                 ///< Accumulated cost from root
+
+    /// @brief Default constructor
+  RRTNode() = default;
+
+    /**
+     * @brief Construct node with specific index and optional cost
+     * @param idx Grid cell index
+     * @param c Initial cost (default 0.0)
+     */
+  explicit RRTNode(const grid_map::Index & idx, double c = 0.0)
+  : index(idx), cost(c)
+  {
+  }
+
+    /**
+     * @brief Change parent of this node and update cumulative cost
+     * @param new_parent New parent node
+     * @param new_cost Updated cumulative cost
+     *
+     * Note: children list is not automatically updated for performance reasons.
+     */
+  void change_parent(std::shared_ptr<RRTNode> new_parent, double new_cost)
+  {
+    parent = new_parent;
+    cost = new_cost;
+  }
+};
+
+} // namespace easynav
+
+#endif // EASYNAV_GRIDMAP_RRTSTAR_PLANNER__RRTNODE_HPP_

--- a/easynav_gridmap_rrtstar_planner/package.xml
+++ b/easynav_gridmap_rrtstar_planner/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>easynav_gridmap_rrtstar_planner</name>
+  <version>0.0.1</version>
+  <description>Easy Navigation: RRT star planner package.</description>
+  <maintainer email="e.aguado.glez@gmail.com">estherag</maintainer>
+  <license>GPL-3.0-only</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>easynav_common</depend>
+  <depend>easynav_core</depend>
+  <depend>pluginlib</depend>
+  <depend>nav_msgs</depend>
+  <depend>grid_map_ros</depend>
+  <depend>grid_map_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
+++ b/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
@@ -1,0 +1,537 @@
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <algorithm>
+#include <random>
+#include <queue>
+#include <unordered_set>
+
+#include "grid_map_core/GridMap.hpp"
+#include "nav_msgs/msg/goals.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.hpp"
+#include "easynav_gridmap_rrtstar_planner/KDTree.hpp"
+#include "tf2/LinearMath/Quaternion.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+namespace easynav
+{
+grid_map::Index GridMapRRTStarPlanner::random_index(
+  const grid_map::GridMap & map,
+  std::mt19937 & rng)
+{
+  std::uniform_int_distribution<int> dist_x(0, map.getSize()[0] - 1);
+  std::uniform_int_distribution<int> dist_y(0, map.getSize()[1] - 1);
+  return {dist_x(rng), dist_y(rng)};
+}
+
+double compute_path_length(const nav_msgs::msg::Path & path)
+{
+  if (path.poses.size() < 2) {
+    return 0.0;
+  }
+
+  double total_length = 0.0;
+  for (size_t i = 1; i < path.poses.size(); ++i) {
+    const auto & p1 = path.poses[i - 1].pose.position;
+    const auto & p2 = path.poses[i].pose.position;
+    total_length += std::hypot(p2.x - p1.x, p2.y - p1.y);
+  }
+  return total_length;
+}
+
+GridMapRRTStarPlanner::GridMapRRTStarPlanner()
+: kd_tree_(std::make_unique<KDTree>())
+{
+  NavState::register_printer<nav_msgs::msg::Path>(
+    [](const nav_msgs::msg::Path & path)
+    {
+      std::ostringstream ret;
+      ret           << "Path with " << path.poses.size() << " poses, length "
+                    << compute_path_length(path) << " m.";
+      return ret.str();
+            });
+}
+
+std::expected<void, std::string> GridMapRRTStarPlanner::on_initialize()
+{
+  auto node = get_node();
+  const auto & plugin_name = get_plugin_name();
+
+  node->declare_parameter<double>(plugin_name + ".max_allowed_slope_deg", 40.0);
+  node->declare_parameter<int>(plugin_name + ".max_iters", 3000);
+  node->declare_parameter<double>(plugin_name + ".step_size", 1.0);
+  node->declare_parameter<double>(plugin_name + ".neighbor_radius", 2.0);
+  node->declare_parameter<double>(plugin_name + ".goal_bias", 0.15);
+  node->declare_parameter<double>(plugin_name + ".goal_threshold", 0.5);
+  node->declare_parameter<int>(plugin_name + ".kdtree_rebuild_interval", 800);
+  node->declare_parameter<double>(plugin_name + ".spacing", 0.2);
+
+  node->get_parameter(plugin_name + ".max_allowed_slope_deg", max_allowed_slope_deg_);
+  node->get_parameter(plugin_name + ".max_iters", max_iters_);
+  node->get_parameter(plugin_name + ".step_size", step_size_);
+  node->get_parameter(plugin_name + ".neighbor_radius", neighbor_radius_);
+  node->get_parameter(plugin_name + ".goal_bias", goal_bias_);
+  node->get_parameter(plugin_name + ".goal_threshold", goal_threshold_);
+  node->get_parameter(plugin_name + ".kdtree_rebuild_interval", kdtree_rebuild_interval_);
+  node->get_parameter(plugin_name + ".spacing", spacing_);
+
+  max_allowed_slope_ = max_allowed_slope_deg_ * M_PI / 180.0;
+
+  path_pub_ = node->create_publisher<nav_msgs::msg::Path>("planner/path", 10);
+
+  node->get_logger().set_level(rclcpp::Logger::Level::Debug);
+
+  return {};
+}
+
+grid_map::Index GridMapRRTStarPlanner::steer(
+  const grid_map::GridMap & map,
+  const grid_map::Index & from,
+  const grid_map::Index & to)
+{
+
+        // Convert indices to continuous map positions
+  grid_map::Position p_from, p_to;
+  map.getPosition(from, p_from);
+  map.getPosition(to, p_to);
+
+        // Compute vector from 'from' to 'to' and its Euclidean distance
+  double dx = p_to.x() - p_from.x();
+  double dy = p_to.y() - p_from.y();
+  double dist = std::hypot(dx, dy);
+
+  grid_map::Position p_new;
+  if (dist <= step_size_) {
+            // Target is within one step: move directly to it
+    p_new = p_to;
+  } else {
+            // Move along the line by 'step_size_' toward target
+    double ratio = step_size_ / dist;
+    p_new = grid_map::Position(p_from.x() + dx * ratio,
+                                       p_from.y() + dy * ratio);
+  }
+
+        // Convert continuous position back to map index
+  grid_map::Index new_idx;
+  if (!map.getIndex(p_new, new_idx)) {
+            // New position is outside map bounds
+    return grid_map::Index(-1, -1);
+  }
+
+  return new_idx;
+}
+
+std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
+  const grid_map::GridMap & map,
+  const geometry_msgs::msg::Pose & start,
+  const geometry_msgs::msg::Pose & goal)
+{
+  std::vector<std::shared_ptr<RRTNode>> tree;
+  std::mt19937 rng(std::random_device{}());
+  std::uniform_real_distribution<double> prob_dist(0.0, 1.0);
+
+  grid_map::Index start_idx, goal_idx;
+  if (!map.getIndex(grid_map::Position(start.position.x, start.position.y), start_idx) ||
+    !map.getIndex(grid_map::Position(goal.position.x, goal.position.y), goal_idx))
+  {
+    throw std::runtime_error("Start or goal position is outside map bounds");
+  }
+
+  auto root = std::make_shared<RRTNode>();
+  root->index = start_idx;
+  root->cost = 0.0;
+  tree.push_back(root);
+
+  std::shared_ptr<RRTNode> best_goal_node = nullptr;
+  double best_goal_cost = std::numeric_limits<double>::max();
+
+  for (int iter = 0; iter < max_iters_; ++iter) {
+    grid_map::Index rand_idx = (prob_dist(rng) < goal_bias_) ? goal_idx : random_index(map, rng);
+    auto nearest = find_nearest(tree, rand_idx, map);
+    if (!nearest) {
+      continue;
+    }
+
+    auto new_idx = steer(map, nearest->index, rand_idx);
+    if ((new_idx == grid_map::Index(-1, -1)).all()) {
+      continue;
+    }
+
+    if (std::any_of(tree.begin(), tree.end(),
+      [&new_idx](const std::shared_ptr<RRTNode> & node)
+      {
+        return (node->index == new_idx).all();
+                            }))
+    {
+      continue;
+    }
+    double edge_cost = traversal_cost(map, nearest->index, new_idx);
+    if (!std::isfinite(edge_cost)) {
+      continue;
+    }
+
+    auto new_node = std::make_shared<RRTNode>();
+    new_node->index = new_idx;
+    new_node->cost = nearest->cost + edge_cost;
+    new_node->parent = nearest;
+
+            // RRT* optimization: try to choose a better parent from nearby nodes
+    double rewire_radius_ = 2.0;
+    for (const auto & near_node : tree) {
+      if (distance(map, near_node->index, new_idx) > rewire_radius_) {
+        continue;
+      }
+
+      double cost = traversal_cost(map, near_node->index, new_idx);
+      if (!std::isfinite(cost)) {
+        continue;
+      }
+
+      double total = near_node->cost + cost;
+      if (total < new_node->cost) {
+        new_node->cost = total;
+        new_node->parent = near_node;
+      }
+    }
+
+    tree.push_back(new_node);
+
+            // Rewiring: try to improve costs of nearby existing nodes
+    for (auto & near_node : tree) {
+      if (near_node == new_node) {
+        continue;
+      }
+      if (distance(map, new_idx, near_node->index) > rewire_radius_) {
+        continue;
+      }
+
+      double cost = traversal_cost(map, new_idx, near_node->index);
+      if (!std::isfinite(cost)) {
+        continue;
+      }
+
+      double total = new_node->cost + cost;
+      if (total < near_node->cost) {
+        near_node->cost = total;
+        near_node->parent = new_node;
+      }
+    }
+
+            // Check if new node is close enough to goal
+    if (distance(map, new_idx, goal_idx) < goal_threshold_) {
+      double goal_cost = traversal_cost(map, new_idx, goal_idx);
+      if (std::isfinite(goal_cost)) {
+        double total = new_node->cost + goal_cost;
+        if (total < best_goal_cost) {
+          best_goal_node = new_node;
+          best_goal_cost = total;
+        }
+      }
+    }
+  }
+
+  auto raw_path = extract_path(best_goal_node, map, goal);
+  raw_path = smooth_path(raw_path, 5);
+
+  return raw_path;
+}
+
+std::shared_ptr<RRTNode> GridMapRRTStarPlanner::find_nearest(
+  const std::vector<std::shared_ptr<RRTNode>> & tree,
+  const grid_map::Index & target,
+  const grid_map::GridMap & map)
+{
+  if (tree.empty()) {
+    return nullptr;
+  }
+
+  return *std::min_element(tree.begin(), tree.end(),
+           [&](const auto & a, const auto & b)
+           {
+             return distance(map, a->index, target) < distance(map, b->index, target);
+                                 });
+}
+
+double GridMapRRTStarPlanner::distance(
+  const grid_map::GridMap & map,
+  const grid_map::Index & a,
+  const grid_map::Index & b)
+{
+  grid_map::Position pa, pb;
+  map.getPosition(a, pa);
+  map.getPosition(b, pb);
+  return std::hypot(pb.x() - pa.x(), pb.y() - pa.y());
+}
+
+std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
+  std::shared_ptr<RRTNode> goal_node,
+  const grid_map::GridMap & map,
+  const geometry_msgs::msg::Pose & goal)
+{
+        // Collect nodes from goal back to start by following parent links
+  std::vector<std::shared_ptr<RRTNode>> nodes;
+  nodes.reserve(100);
+
+  for (auto current = goal_node; current; current = current->parent) {
+    nodes.push_back(current);
+  }
+        // Reverse to get path from start to goal
+  std::reverse(nodes.begin(), nodes.end());
+
+        // Convert RRT nodes to ROS poses
+  std::vector<geometry_msgs::msg::Pose> path;
+  path.reserve(nodes.size());
+
+  for (size_t i = 0; i < nodes.size(); ++i) {
+    const auto & node = nodes[i];
+    grid_map::Position pos;
+    map.getPosition(node->index, pos);
+
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = pos.x();
+    pose.position.y = pos.y();
+    pose.position.z = map.at("elevation", node->index);         // Set z using elevation layer
+
+            // Compute orientation if there is a next node
+    if (i + 1 < nodes.size()) {
+      grid_map::Position next_pos;
+      map.getPosition(nodes[i + 1]->index, next_pos);
+
+      double dx = next_pos.x() - pos.x();
+      double dy = next_pos.y() - pos.y();
+      double yaw = std::atan2(dy, dx);
+
+      tf2::Quaternion q;
+      q.setRPY(0, 0, yaw);
+      pose.orientation = tf2::toMsg(q);
+    }
+
+    path.push_back(pose);
+  }
+
+  if (!path.empty()) {
+    path.back().orientation = goal.orientation;
+  }
+
+  return path;
+}
+
+double GridMapRRTStarPlanner::traversal_cost(
+  const grid_map::GridMap & map,
+  const grid_map::Index & to,
+  const grid_map::Index & from)
+{
+        // Use a unique key (based on flattened indices) to identify the edge.
+  const uint32_t width = static_cast<uint32_t>(map.getSize()[0]);
+  const uint64_t key = edge_key(flat_index(from, width), flat_index(to, width));
+
+  if (auto it = cost_cache_.find(key); it != cost_cache_.end()) {
+    return it->second;
+  }
+
+  grid_map::Position pos_from, pos_to;
+  map.getPosition(from, pos_from);
+  map.getPosition(to, pos_to);
+
+  if (!map.isInside(pos_from) || !map.isInside(pos_to)) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  if (!map.isValid(from, "elevation") || !map.isValid(to, "elevation")) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  double z1 = map.at("elevation", from);
+  double z2 = map.at("elevation", to);
+  double dx = map.getResolution() * (to.x() - from.x());
+  double dy = map.getResolution() * (to.y() - from.y());
+  double dz = z2 - z1;
+  double horizontal_dist = std::hypot(dx, dy);
+
+        // Flat surface: cost = horizontal distance
+  if (std::abs(dz) < 1e-3) {
+    return cost_cache_[key] = horizontal_dist;
+  }
+
+        // Calculate slope
+  double slope_rad = std::atan2(std::abs(dz), horizontal_dist);
+
+        // Reject edges with slope exceeding maximum allowed
+  if (slope_rad > max_allowed_slope_) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  const double distance_3d = std::sqrt(dx * dx + dy * dy + dz * dz);
+
+  const double slope_factor = 1.0 + std::pow(slope_rad / max_allowed_slope_, 2.0);
+
+  const double final_cost = distance_3d * slope_factor;
+
+  return cost_cache_[key] = final_cost;
+}
+void GridMapRRTStarPlanner::clear_cost_cache()
+{
+  cost_cache_.clear();
+  cached_map_width_ = 0;
+  cached_map_height_ = 0;
+  last_map_timestamp_ = 0;
+}
+
+uint32_t GridMapRRTStarPlanner::flat_index(const grid_map::Index & idx, uint32_t width)
+{
+  return idx[0] + idx[1] * width;
+}
+
+uint64_t GridMapRRTStarPlanner::edge_key(uint32_t a_flat, uint32_t b_flat)
+{
+  return (static_cast<uint64_t>(a_flat) << 32) | b_flat;
+}
+
+void GridMapRRTStarPlanner::update(NavState & nav_state)
+{
+  current_path_.poses.clear();
+
+  if (!nav_state.has("goals") || !nav_state.has("robot_pose") || !nav_state.has("map")) {
+    RCLCPP_DEBUG(
+                get_node()->get_logger(), "goals, robot_pose or map missing. Returning");
+    return;
+  }
+
+  const auto goals = nav_state.get<nav_msgs::msg::Goals>("goals");
+  if (goals.goals.empty()) {
+    RCLCPP_DEBUG(
+                get_node()->get_logger(), "goals empty. Returning empty path");
+    nav_state.set("path", current_path_);
+    return;
+  }
+
+  const auto & robot_pose = nav_state.get<nav_msgs::msg::Odometry>("robot_pose");
+  const auto & goal_pose = goals.goals.front().pose;
+  const auto & map = nav_state.get<grid_map::GridMap>("map");
+
+  clear_cost_cache();
+  kd_tree_ = std::make_unique<KDTree>();
+
+  auto new_poses = rrt_star(map, robot_pose.pose.pose, goal_pose);
+
+  if (!new_poses.empty()) {
+    nav_msgs::msg::Path new_path;
+    new_path.header.stamp = get_node()->now();
+    new_path.header.frame_id = goals.header.frame_id;
+
+    for (const auto & pose : new_poses) {
+      geometry_msgs::msg::PoseStamped ps;
+      ps.header = new_path.header;
+      ps.pose = pose;
+      new_path.poses.push_back(ps);
+    }
+
+    current_path_ = new_path;
+    nav_state.set("path", current_path_);
+
+    if (path_pub_->get_subscription_count() > 0) {
+      path_pub_->publish(current_path_);
+    }
+  }
+}
+
+std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
+  const std::vector<geometry_msgs::msg::Pose> & input_path,
+  int interpolation_points_per_segment)
+{
+  std::vector<geometry_msgs::msg::Pose> smoothed;
+
+  if (input_path.size() < 4) {
+    return input_path;
+  }
+
+  for (size_t i = 1; i < input_path.size() - 2; ++i) {
+    const auto & p0 = input_path[i - 1].position;
+    const auto & p1 = input_path[i].position;
+    const auto & p2 = input_path[i + 1].position;
+    const auto & p3 = input_path[i + 2].position;
+
+    for (int j = 0; j < interpolation_points_per_segment; ++j) {
+      double t = static_cast<double>(j) / interpolation_points_per_segment;
+      geometry_msgs::msg::Pose pose;
+
+                // Catmull–Rom spline
+      pose.position.x = 0.5 * ((2 * p1.x) +
+        (-p0.x + p2.x) * t +
+        (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t * t +
+        (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t * t * t);
+
+      pose.position.y = 0.5 * ((2 * p1.y) +
+        (-p0.y + p2.y) * t +
+        (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t * t +
+        (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t * t * t);
+
+      pose.position.z = 0.5 * ((2 * p1.z) +
+        (-p0.z + p2.z) * t +
+        (2 * p0.z - 5 * p1.z + 4 * p2.z - p3.z) * t * t +
+        (-p0.z + 3 * p1.z - 3 * p2.z + p3.z) * t * t * t);
+
+      if (!smoothed.empty()) {
+        const auto & prev = smoothed.back().position;
+        double dx = pose.position.x - prev.x;
+        double dy = pose.position.y - prev.y;
+
+        if (std::hypot(dx, dy) > 1e-6) {
+          double yaw = std::atan2(dy, dx);
+          tf2::Quaternion q;
+          q.setRPY(0, 0, yaw);
+          pose.orientation = tf2::toMsg(q);
+        } else {
+          pose.orientation = smoothed.back().orientation;
+        }
+      } else {
+        double dx = p2.x - p1.x;
+        double dy = p2.y - p1.y;
+        double yaw = std::atan2(dy, dx);
+        tf2::Quaternion q;
+        q.setRPY(0, 0, yaw);
+        pose.orientation = tf2::toMsg(q);
+      }
+
+                // Avoid too much points, minimal spacing
+      if (!smoothed.empty()) {
+        const auto & prev = smoothed.back().position;
+        if (std::hypot(pose.position.x - prev.x,
+                                   pose.position.y - prev.y) < spacing_)
+        {
+          continue;
+        }
+      }
+
+      smoothed.push_back(pose);
+    }
+  }
+
+        // Add last original waypoint with correct orientation
+  if (!input_path.empty()) {
+    geometry_msgs::msg::Pose last = input_path.back();
+    if (!smoothed.empty()) {
+      const auto & prev = smoothed.back().position;
+      double dx = last.position.x - prev.x;
+      double dy = last.position.y - prev.y;
+      if (std::hypot(dx, dy) > 1e-6) {
+        double yaw = std::atan2(dy, dx);
+        tf2::Quaternion q;
+        q.setRPY(0, 0, yaw);
+        last.orientation = tf2::toMsg(q);
+      } else {
+        last.orientation = smoothed.back().orientation;
+      }
+    }
+    smoothed.push_back(last);
+  }
+
+  return smoothed;
+}
+
+} // namespace easynav
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(easynav::GridMapRRTStarPlanner, easynav::PlannerMethodBase)

--- a/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
+++ b/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
@@ -70,10 +70,10 @@ GridMapRRTStarPlanner::GridMapRRTStarPlanner()
     [](const nav_msgs::msg::Path & path)
     {
       std::ostringstream ret;
-      ret     << "Path with " << path.poses.size() << " poses, length "
-              << compute_path_length(path) << " m.";
+      ret << "Path with " << path.poses.size() << " poses, length "
+          << compute_path_length(path) << " m.";
       return ret.str();
-        });
+    });
 }
 
 std::expected<void, std::string> GridMapRRTStarPlanner::on_initialize()
@@ -102,7 +102,7 @@ std::expected<void, std::string> GridMapRRTStarPlanner::on_initialize()
   node->get_parameter(plugin_name + ".spacing", spacing_);
   node->get_parameter(plugin_name + ".max_lateral_deviation", max_lateral_deviation_);
   node->get_parameter(plugin_name + ".final_poses_with_goal_orientation",
-                        final_poses_with_goal_orientation_);
+                      final_poses_with_goal_orientation_);
 
   max_allowed_slope_ = max_allowed_slope_deg_ * M_PI / 180.0;
 
@@ -128,31 +128,31 @@ grid_map::Index GridMapRRTStarPlanner::steer(
   const grid_map::Index & to)
 {
 
-    // Convert indices to continuous map positions
+  // Convert indices to continuous map positions
   grid_map::Position p_from, p_to;
   map.getPosition(from, p_from);
   map.getPosition(to, p_to);
 
-    // Compute vector from 'from' to 'to' and its Euclidean distance
+  // Compute vector from 'from' to 'to' and its Euclidean distance
   double dx = p_to.x() - p_from.x();
   double dy = p_to.y() - p_from.y();
   double dist = std::hypot(dx, dy);
 
   grid_map::Position p_new;
   if (dist <= step_size_) {
-      // Target is within one step: move directly to it
+    // Target is within one step: move directly to it
     p_new = p_to;
   } else {
-      // Move along the line by 'step_size_' toward target
+    // Move along the line by 'step_size_' toward target
     double ratio = step_size_ / dist;
     p_new = grid_map::Position(p_from.x() + dx * ratio,
-                                 p_from.y() + dy * ratio);
+                               p_from.y() + dy * ratio);
   }
 
-    // Convert continuous position back to map index
+  // Convert continuous position back to map index
   grid_map::Index new_idx;
   if (!map.getIndex(p_new, new_idx)) {
-      // New position is outside map bounds
+    // New position is outside map bounds
     return grid_map::Index(-1, -1);
   }
 
@@ -177,7 +177,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
     return {};
   }
 
-    // get robot yaw from the start pose for forward-biased sampling
+  // get robot yaw from the start pose for forward-biased sampling
   tf2::Quaternion robot_q;
   tf2::fromMsg(start.orientation, robot_q);
   double robot_roll, robot_pitch, robot_yaw;
@@ -196,7 +196,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
   const int min_iterations = max_iters_ / 2;
 
   for (int iter = 0; iter < max_iters_; ++iter) {
-      // adaptive goal bias: increase bias if a candidate path exists, else grow modestly
+    // adaptive goal bias: increase bias if a candidate path exists, else grow modestly
     double adaptive_goal_bias = goal_bias_;
 
     if (best_goal_node) {
@@ -209,7 +209,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
     if (prob_dist(rng) < adaptive_goal_bias) {
       rand_idx = goal_idx;
     } else {
-        // early iterations: bias samples forward relative to robot heading, otherwise sample uniformly
+      // early iterations: bias samples forward relative to robot heading, otherwise sample uniformly
       if (iter < 100 && tree.size() < 50) {
         rand_idx = biased_random_index(map, start, robot_yaw, rng);
       } else {
@@ -227,7 +227,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       continue;
     }
 
-      // skip exact duplicates and very close nodes when tree is large
+    // skip exact duplicates and very close nodes when tree is large
     bool duplicate = false;
     for (const auto & node : tree) {
       if ((node->index == new_idx).all()) {
@@ -243,7 +243,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       continue;
     }
 
-      // compute full traversal cost for the new edge and skip infeasible edges
+    // compute full traversal cost for the new edge and skip infeasible edges
     double edge_cost = traversal_cost(map, nearest->index, new_idx);
     if (!std::isfinite(edge_cost)) {
       continue;
@@ -254,11 +254,11 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
     new_node->cost = nearest->cost + edge_cost;
     new_node->parent = nearest;
 
-      // collect nearby nodes for potential rewiring using a dynamic radius
+    // collect nearby nodes for potential rewiring using a dynamic radius
     std::vector<std::shared_ptr<RRTNode>> nearby_nodes;
     double search_radius = std::min(neighbor_radius_,
-                                      neighbor_radius_ *
-                                          std::sqrt(std::log(tree.size()) / tree.size()));
+                                    neighbor_radius_ *
+                                    std::sqrt(std::log(tree.size()) / tree.size()));
 
     for (const auto & near_node : tree) {
       double dist = distance(map, near_node->index, new_idx);
@@ -267,17 +267,17 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       }
     }
 
-      // limit number of neighbors considered, keeping closest ones
+    // limit number of neighbors considered, keeping closest ones
     if (nearby_nodes.size() > 8) {
       std::nth_element(nearby_nodes.begin(), nearby_nodes.begin() + 15, nearby_nodes.end(),
         [&](const auto & a, const auto & b)
         {
           return distance(map, a->index, new_idx) < distance(map, b->index, new_idx);
-                         });
+        });
       nearby_nodes.resize(8);
     }
 
-      // choose the best parent among nearby nodes to minimize cost
+    // choose the best parent among nearby nodes to minimize cost
     for (const auto & near_node : nearby_nodes) {
       double cost = traversal_cost(map, near_node->index, new_idx);
       if (!std::isfinite(cost)) {
@@ -293,7 +293,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
 
     tree.push_back(new_node);
 
-      // try to rewire nearby nodes through the new node if it lowers their cost
+    // try to rewire nearby nodes through the new node if it lowers their cost
     for (auto & near_node : nearby_nodes) {
       if (near_node == new_node || near_node == root) {
         continue;
@@ -305,13 +305,13 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       }
 
       double total = new_node->cost + cost;
-      if (total < near_node->cost - 0.01) { // small threshold to avoid oscillation
+      if (total < near_node->cost - 0.01) {                   // small threshold to avoid oscillation
         near_node->cost = total;
         near_node->parent = new_node;
       }
     }
 
-      // check proximity to goal and update best solution if improved
+    // check proximity to goal and update best solution if improved
     double dist_to_goal = distance(map, new_idx, goal_idx);
     if (dist_to_goal < goal_threshold_) {
       double goal_cost = traversal_cost(map, new_idx, goal_idx);
@@ -323,25 +323,25 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
           iterations_without_improvement = 0;
 
           RCLCPP_DEBUG(get_node()->get_logger(),
-                         "New best goal found at iteration %d with cost %.2f (dist: %.2f)",
-                         iter, best_goal_cost, dist_to_goal);
+                       "New best goal found at iteration %d with cost %.2f (dist: %.2f)",
+                       iter, best_goal_cost, dist_to_goal);
 
-            // adaptive early termination: evaluate path efficiency against direct distance
+          // adaptive early termination: evaluate path efficiency against direct distance
           if (iter > min_iterations && best_goal_node) {
             double direct_distance = distance(map, start_idx, goal_idx);
             double path_efficiency = best_goal_cost / direct_distance;
 
             if (path_efficiency < 1.3 && iter > 2000) {
               RCLCPP_DEBUG(get_node()->get_logger(),
-                             "Early termination: efficient path found (%.1f%% of direct) at iter %d",
-                             path_efficiency * 100, iter);
+                           "Early termination: efficient path found (%.1f%% of direct) at iter %d",
+                           path_efficiency * 100, iter);
               break;
             }
 
             if (path_efficiency < 1.1 && iter > 1000) {
               RCLCPP_DEBUG(get_node()->get_logger(),
-                             "Very efficient path found (%.1f%%), early exit at iter %d",
-                             path_efficiency * 100, iter);
+                           "Very efficient path found (%.1f%%), early exit at iter %d",
+                           path_efficiency * 100, iter);
               break;
             }
           }
@@ -353,7 +353,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       iterations_without_improvement++;
     }
 
-      // adaptive termination when no improvement for many iterations, scaled by tree size
+    // adaptive termination when no improvement for many iterations, scaled by tree size
     int max_no_improvement_adaptive = max_no_improvement;
     if (tree.size() > 1000) {
       max_no_improvement_adaptive = 50;
@@ -364,8 +364,8 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
 
     if (iterations_without_improvement > max_no_improvement_adaptive && best_goal_node) {
       RCLCPP_DEBUG(get_node()->get_logger(),
-                     "No improvement termination at iteration %d (tree size: %zu)",
-                     iter, tree.size());
+                   "No improvement termination at iteration %d (tree size: %zu)",
+                   iter, tree.size());
       break;
     }
   }
@@ -382,12 +382,12 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
     return {};
   }
 
-    // apply conservative smoothing to the raw path
+  // apply conservative smoothing to the raw path
   raw_path = smooth_path(raw_path, 4);
 
   RCLCPP_DEBUG(get_node()->get_logger(),
-                 "Generated RRT* path with %zu points, cost %.2f, tree size: %zu",
-                 raw_path.size(), best_goal_cost, tree.size());
+               "Generated RRT* path with %zu points, cost %.2f, tree size: %zu",
+               raw_path.size(), best_goal_cost, tree.size());
 
   new_path_cost_ = best_goal_cost;
   return raw_path;
@@ -399,22 +399,22 @@ grid_map::Index GridMapRRTStarPlanner::biased_random_index(
   double robot_yaw,
   std::mt19937 & rng)
 {
-    // Generate samples biased forward relative to the robot heading.
-    // Angle in ±60° in front, distance between 1 and 5 meters.
+  // Generate samples biased forward relative to the robot heading.
+  // Angle in ±60° in front, distance between 1 and 5 meters.
   std::uniform_real_distribution<double> angle_dist(-M_PI / 3, M_PI / 3);
   std::uniform_real_distribution<double> dist_dist(1.0, 5.0);
 
   double bias_angle = robot_yaw + angle_dist(rng);
   double bias_distance = dist_dist(rng);
 
-    // Compute biased target position in world coordinates
+  // Compute biased target position in world coordinates
   double target_x = robot_pose.position.x + bias_distance * std::cos(bias_angle);
   double target_y = robot_pose.position.y + bias_distance * std::sin(bias_angle);
 
   grid_map::Index biased_idx;
   grid_map::Position target_pos(target_x, target_y);
 
-    // If biased point is inside the map, return its index, otherwise fall back
+  // If biased point is inside the map, return its index, otherwise fall back
   if (map.getIndex(target_pos, biased_idx)) {
     return biased_idx;
   } else {
@@ -431,12 +431,12 @@ std::shared_ptr<RRTNode> GridMapRRTStarPlanner::find_nearest(
     return nullptr;
   }
 
-    // Return the node in 'tree' with minimum Euclidean distance to 'target'
+  // Return the node in 'tree' with minimum Euclidean distance to 'target'
   return *std::min_element(tree.begin(), tree.end(),
            [&](const auto & a, const auto & b)
            {
              return distance(map, a->index, target) < distance(map, b->index, target);
-                             });
+    });
 }
 
 double GridMapRRTStarPlanner::distance(
@@ -451,7 +451,7 @@ double GridMapRRTStarPlanner::distance(
   return std::hypot(pb.x() - pa.x(), pb.y() - pa.y());
 }
 
-  // Replace previous implementation: trim path by removing waypoints behind or already passed by the robot
+// Replace previous implementation: trim path by removing waypoints behind or already passed by the robot
 nav_msgs::msg::Path GridMapRRTStarPlanner::trim_path_from_robot(
   const nav_msgs::msg::Path & path,
   const geometry_msgs::msg::Pose & robot_pose) const
@@ -462,11 +462,11 @@ nav_msgs::msg::Path GridMapRRTStarPlanner::trim_path_from_robot(
     return trimmed_path;
   }
 
-  const double trim_distance = 1.0;   // meters: threshold to consider a waypoint "passed"
+  const double trim_distance = 1.0;       // meters: threshold to consider a waypoint "passed"
   size_t closest_index = 0;
   double min_distance = std::numeric_limits<double>::max();
 
-    // Find the closest waypoint to the robot
+  // Find the closest waypoint to the robot
   for (size_t i = 0; i < path.poses.size(); ++i) {
     const auto & wp = path.poses[i].pose.position;
     const auto & rp = robot_pose.position;
@@ -477,30 +477,30 @@ nav_msgs::msg::Path GridMapRRTStarPlanner::trim_path_from_robot(
     }
   }
 
-    // Identify previous waypoints that are very close (already visited)
+  // Identify previous waypoints that are very close (already visited)
   size_t start_index = closest_index;
   for (size_t i = 0; i <= closest_index; ++i) {
     const auto & wp = path.poses[i].pose.position;
     const auto & rp = robot_pose.position;
     double d = std::hypot(wp.x - rp.x, wp.y - rp.y);
     if (d < trim_distance) {
-      start_index = i + 1;   // mark for removal
+      start_index = i + 1;                   // mark for removal
     } else {
       break;
     }
   }
 
-    // Ensure we keep at least the closest waypoint
+  // Ensure we keep at least the closest waypoint
   if (start_index > closest_index) {
     start_index = closest_index;
   }
 
-    // Erase the earlier segment only if enough waypoints remain after trimming
+  // Erase the earlier segment only if enough waypoints remain after trimming
   if (start_index > 0 && (path.poses.size() - start_index) >= 3) {
     trimmed_path.poses.erase(trimmed_path.poses.begin(), trimmed_path.poses.begin() + start_index);
     RCLCPP_DEBUG(get_node()->get_logger(),
-                   "Path trimmed: removed %zu waypoints, %zu remaining (closest at %.2fm)",
-                   start_index, trimmed_path.poses.size(), min_distance);
+                 "Path trimmed: removed %zu waypoints, %zu remaining (closest at %.2fm)",
+                 start_index, trimmed_path.poses.size(), min_distance);
   }
 
   return trimmed_path;
@@ -514,7 +514,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
   std::vector<std::shared_ptr<RRTNode>> nodes;
   nodes.reserve(100);
 
-    // collect nodes from the RRT tree back to the root
+  // collect nodes from the RRT tree back to the root
   for (auto current = goal_node; current; current = current->parent) {
     nodes.push_back(current);
   }
@@ -523,7 +523,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
   std::vector<geometry_msgs::msg::Pose> path;
   path.reserve(nodes.size());
 
-    // convert tree nodes to basic poses (no smoothing here)
+  // convert tree nodes to basic poses (no smoothing here)
   for (size_t i = 0; i < nodes.size(); ++i) {
     const auto & node = nodes[i];
     grid_map::Position pos;
@@ -534,7 +534,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
     pose.position.y = pos.y();
     pose.position.z = map.at("elevation", node->index);
 
-      // DEFAULT ORIENTATION: neutral (facing along x-axis)
+    // DEFAULT ORIENTATION: neutral (facing along x-axis)
     tf2::Quaternion q;
     q.setRPY(0, 0, 0);
     pose.orientation = tf2::toMsg(q);
@@ -542,13 +542,13 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
     path.push_back(pose);
   }
 
-    // for the final raw waypoint, apply the goal orientation
+  // for the final raw waypoint, apply the goal orientation
   if (!path.empty()) {
     path.back().orientation = goal.orientation;
   }
 
   RCLCPP_DEBUG(get_node()->get_logger(),
-                 "Path extracted with %zu raw RRT* nodes (no smoothing)", path.size());
+               "Path extracted with %zu raw RRT* nodes (no smoothing)", path.size());
 
   return path;
 }
@@ -563,13 +563,13 @@ double GridMapRRTStarPlanner::calculate_lateral_distance_to_path(
 
   double min_distance = std::numeric_limits<double>::max();
 
-    // Find the closest point on any path segment to the robot
+  // Find the closest point on any path segment to the robot
   for (size_t i = 0; i < path.poses.size() - 1; ++i) {
     const auto & p1 = path.poses[i].pose.position;
     const auto & p2 = path.poses[i + 1].pose.position;
     const auto & rp = robot_pose.position;
 
-      // Project robot position onto the vector p1->p2 and clamp to the segment
+    // Project robot position onto the vector p1->p2 and clamp to the segment
     double vx = p2.x - p1.x;
     double vy = p2.y - p1.y;
     double wx = rp.x - p1.x;
@@ -579,7 +579,7 @@ double GridMapRRTStarPlanner::calculate_lateral_distance_to_path(
     double len_sq = vx * vx + vy * vy;
 
     if (len_sq < 1e-6) {
-        // degenerate segment, skip
+      // degenerate segment, skip
       continue;
     }
 
@@ -608,7 +608,7 @@ double GridMapRRTStarPlanner::traversal_cost(
   const grid_map::Index & from,
   const grid_map::Index & to)
 {
-    // Use a unique key (based on flattened indices) to identify the edge.
+  // Use a unique key (based on flattened indices) to identify the edge.
   const uint32_t width = static_cast<uint32_t>(map.getSize()[0]);
   const uint64_t key = edge_key(flat_index(from, width), flat_index(to, width));
 
@@ -635,15 +635,15 @@ double GridMapRRTStarPlanner::traversal_cost(
   double dz = z2 - z1;
   double horizontal_dist = std::hypot(dx, dy);
 
-    // Flat surface: cost = horizontal distance
+  // Flat surface: cost = horizontal distance
   if (std::abs(dz) < 1e-3) {
     return cost_cache_[key] = horizontal_dist;
   }
 
-    // Calculate slope
+  // Calculate slope
   double slope_rad = std::atan2(std::abs(dz), horizontal_dist);
 
-    // Reject edges with slope exceeding maximum allowed
+  // Reject edges with slope exceeding maximum allowed
   if (slope_rad > max_allowed_slope_) {
     return std::numeric_limits<double>::infinity();
   }
@@ -677,25 +677,25 @@ uint64_t GridMapRRTStarPlanner::edge_key(uint32_t a_flat, uint32_t b_flat)
 
 bool GridMapRRTStarPlanner::check_goal_changed(const geometry_msgs::msg::Pose & goal_pose)
 {
-    // tolerance used for comparing goal positions
+  // tolerance used for comparing goal positions
   const double tolerance = goal_threshold_;
 
-    // check if the goal has changed significantly
+  // check if the goal has changed significantly
   bool goal_changed = (std::abs(goal_pose.position.x - last_goal_pose_.position.x) > tolerance ||
     std::abs(goal_pose.position.y - last_goal_pose_.position.y) > tolerance ||
     std::abs(goal_pose.position.z - last_goal_pose_.position.z) > tolerance);
 
   if (goal_changed) {
-    last_goal_pose_ = goal_pose;   // update last known goal
+    last_goal_pose_ = goal_pose;             // update last known goal
   }
 
   return goal_changed;
 }
 
-  // Replace entire update() function:
+// Replace entire update() function:
 void GridMapRRTStarPlanner::update(NavState & nav_state)
 {
-    // initial validations
+  // initial validations
   if (!nav_state.has("goals") || !nav_state.has("robot_pose") || !nav_state.has("map")) {
     RCLCPP_DEBUG(get_node()->get_logger(), "goals, robot_pose or map missing. Returning");
     return;
@@ -713,33 +713,33 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
   const auto & goal_pose = goals.goals.front().pose;
   const auto & map = nav_state.get<grid_map::GridMap>("map");
 
-    // evaluate conditions once
+  // evaluate conditions once
   bool goal_changed = check_goal_changed(goal_pose);
   bool robot_deviated = false;
   bool path_too_short = current_path_.poses.size() < 3;
   double lateral_distance = 0.0;
 
-    // check robot deviation only if a path exists
+  // check robot deviation only if a path exists
   if (!current_path_.poses.empty()) {
     lateral_distance = calculate_lateral_distance_to_path(current_path_, robot_pose.pose.pose);
     robot_deviated = (lateral_distance > max_lateral_deviation_);
 
     if (robot_deviated) {
       RCLCPP_INFO(get_node()->get_logger(),
-                    "Robot deviated from path (%.2f m > %.2f m threshold), replanning",
-                    lateral_distance, max_lateral_deviation_);
+                  "Robot deviated from path (%.2f m > %.2f m threshold), replanning",
+                  lateral_distance, max_lateral_deviation_);
     } else {
       RCLCPP_DEBUG(get_node()->get_logger(),
-                     "Robot deviation: %.2f m (within %.2f m threshold)",
-                     lateral_distance, max_lateral_deviation_);
+                   "Robot deviation: %.2f m (within %.2f m threshold)",
+                   lateral_distance, max_lateral_deviation_);
     }
   }
 
-    // decide once whether to replan
+  // decide once whether to replan
   bool needs_replan = goal_changed || robot_deviated || path_too_short;
   bool needs_new_path = needs_replan || current_path_.poses.empty();
 
-    // perform actions based on decision
+  // perform actions based on decision
   if (needs_replan) {
     if (goal_changed) {
       RCLCPP_INFO(get_node()->get_logger(), "New goal detected, regenerating path");
@@ -748,18 +748,18 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
       RCLCPP_INFO(get_node()->get_logger(), "Robot deviated, regenerating path");
     } else if (path_too_short) {
       RCLCPP_DEBUG(get_node()->get_logger(),
-                     "Path too short (%zu waypoints), regenerating",
-                     current_path_.poses.size());
+                   "Path too short (%zu waypoints), regenerating",
+                   current_path_.poses.size());
     }
 
-      // reset state for replanning
+    // reset state for replanning
     current_path_.poses.clear();
     clear_cost_cache();
     current_path_cost_ = std::numeric_limits<double>::max();
     kd_tree_ = std::make_unique<KDTree>();
   }
 
-    // generate a new path if needed
+  // generate a new path if needed
   if (needs_new_path) {
     auto new_poses = generate_new_path(map, robot_pose.pose.pose, goal_pose);
     if (new_poses.empty()) {
@@ -778,19 +778,19 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
       new_path.poses.push_back(ps);
     }
 
-      // accept or compare new path
+    // accept or compare new path
     if (needs_replan) {
       current_path_ = new_path;
       current_path_cost_ = new_path_cost_;
       RCLCPP_DEBUG(get_node()->get_logger(),
-                     "Using new path: cost %.2f, length %.2f m",
-                     new_path_cost_, compute_path_length(new_path));
+                   "Using new path: cost %.2f, length %.2f m",
+                   new_path_cost_, compute_path_length(new_path));
     } else if (current_path_.poses.empty()) {
       current_path_ = new_path;
       current_path_cost_ = new_path_cost_;
       RCLCPP_DEBUG(get_node()->get_logger(),
-                     "Using new path (no previous path): cost %.2f, length %.2f m",
-                     new_path_cost_, compute_path_length(new_path));
+                   "Using new path (no previous path): cost %.2f, length %.2f m",
+                   new_path_cost_, compute_path_length(new_path));
     } else {
       const double improvement_threshold = 5 * goal_threshold_;
 
@@ -802,27 +802,27 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
         current_path_cost_ = new_path_cost_;
 
         RCLCPP_DEBUG(get_node()->get_logger(),
-                       "Updated to better cost path: %.2f -> %.2f (improvement: %.2f)",
-                       old_cost, new_path_cost_, cost_improvement);
+                     "Updated to better cost path: %.2f -> %.2f (improvement: %.2f)",
+                     old_cost, new_path_cost_, cost_improvement);
       } else {
         double cost_difference = new_path_cost_ - current_path_cost_;
         RCLCPP_DEBUG(get_node()->get_logger(),
-                       "Keeping current path: cost %.2f < %.2f (difference: %.2f, threshold: %.2f)",
-                       current_path_cost_, new_path_cost_, cost_difference,
-                       improvement_threshold);
+                     "Keeping current path: cost %.2f < %.2f (difference: %.2f, threshold: %.2f)",
+                     current_path_cost_, new_path_cost_, cost_difference,
+                     improvement_threshold);
       }
     }
   }
 
-    // apply trimming and publish
+  // apply trimming and publish
   if (!current_path_.poses.empty()) {
     size_t original_size = current_path_.poses.size();
     current_path_ = trim_path_from_robot(current_path_, robot_pose.pose.pose);
 
     if (current_path_.poses.size() != original_size) {
       RCLCPP_DEBUG(get_node()->get_logger(),
-                     "Path trimmed: %zu -> %zu waypoints",
-                     original_size, current_path_.poses.size());
+                   "Path trimmed: %zu -> %zu waypoints",
+                   original_size, current_path_.poses.size());
     }
   }
 
@@ -844,14 +844,14 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::generate_new_path(
 {
   std::vector<geometry_msgs::msg::Pose> new_poses;
 
-    // ensure goal is inside map bounds
+  // ensure goal is inside map bounds
   grid_map::Index goal_idx;
   if (!map.getIndex(grid_map::Position(goal_pose.position.x, goal_pose.position.y), goal_idx)) {
     RCLCPP_WARN(get_node()->get_logger(), "Goal is outside the map bounds");
     return new_poses;
   }
 
-    // always plan from robot pose for consistency
+  // always plan from robot pose for consistency
   RCLCPP_DEBUG(get_node()->get_logger(), "Generating new path from robot pose");
   new_poses = rrt_star(map, robot_pose, goal_pose);
 
@@ -862,12 +862,12 @@ void GridMapRRTStarPlanner::publish_path_markers(const nav_msgs::msg::Path & pat
 {
   visualization_msgs::msg::MarkerArray marker_array;
 
-    // clear previous markers
+  // clear previous markers
   visualization_msgs::msg::Marker clear;
   clear.action = visualization_msgs::msg::Marker::DELETEALL;
   marker_array.markers.push_back(clear);
 
-    // create markers for each path pose
+  // create markers for each path pose
   int id = 0;
   for (const auto & pose_stamped : path.poses) {
     visualization_msgs::msg::Marker marker;
@@ -877,15 +877,15 @@ void GridMapRRTStarPlanner::publish_path_markers(const nav_msgs::msg::Path & pat
     marker.type = visualization_msgs::msg::Marker::ARROW;
     marker.action = visualization_msgs::msg::Marker::ADD;
 
-      // set marker pose
+    // set marker pose
     marker.pose = pose_stamped.pose;
 
-      // set marker scale
-    marker.scale.x = 0.3;    // arrow length
-    marker.scale.y = 0.05;   // arrow thickness
+    // set marker scale
+    marker.scale.x = 0.3;             // arrow length
+    marker.scale.y = 0.05;             // arrow thickness
     marker.scale.z = 0.05;
 
-      // set marker color
+    // set marker color
     marker.color.r = 0.1f;
     marker.color.g = 0.1f;
     marker.color.b = 1.0f;
@@ -894,14 +894,14 @@ void GridMapRRTStarPlanner::publish_path_markers(const nav_msgs::msg::Path & pat
     marker_array.markers.push_back(marker);
   }
 
-    // publish markers
+  // publish markers
   marker_pub_->publish(marker_array);
 }
 std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
   const std::vector<geometry_msgs::msg::Pose> & input_path,
   int interpolation_points_per_segment)
 {
-    // Return the input path if it's too short to smooth
+  // Return the input path if it's too short to smooth
   if (input_path.size() < 3) {
     return input_path;
   }
@@ -911,7 +911,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
   const size_t preserve_n = std::max(1, final_poses_with_goal_orientation_);
   const double max_yaw_step = M_PI / 8.0;
 
-    // Precompute positions and tangents
+  // Precompute positions and tangents
   std::vector<grid_map::Position> pts(N);
   std::vector<double> z_values(N);
   for (size_t i = 0; i < N; ++i) {
@@ -939,10 +939,10 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
       0.5 * (z_values[i + 1] - z_values[i - 1]);
   }
 
-    // Add the first point with corrected orientation
+  // Add the first point with corrected orientation
   geometry_msgs::msg::Pose first_pose = input_path.front();
 
-    // Calculate orientation for the first point based on direction to second point
+  // Calculate orientation for the first point based on direction to second point
   if (input_path.size() > 1) {
     double dx = input_path[1].position.x - first_pose.position.x;
     double dy = input_path[1].position.y - first_pose.position.y;
@@ -956,7 +956,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
 
   smoothed.push_back(first_pose);
 
-    // Interpolate between points
+  // Interpolate between points
   for (size_t i = 0; i < N - 1; ++i) {
     const auto & p0 = pts[i], & p1 = pts[i + 1];
     const auto & m0 = tangents[i], & m1 = tangents[i + 1];
@@ -967,7 +967,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
       double t = static_cast<double>(s) / (interpolation_points_per_segment + 1);
       double t2 = t * t, t3 = t2 * t;
 
-        // Hermite interpolation
+      // Hermite interpolation
       double h00 = 2.0 * t3 - 3.0 * t2 + 1.0;
       double h10 = t3 - 2.0 * t2 + t;
       double h01 = -2.0 * t3 + 3.0 * t2;
@@ -978,7 +978,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
       sample.position.y = h00 * p0.y() + h10 * m0.y() + h01 * p1.y() + h11 * m1.y();
       sample.position.z = h00 * z0 + h10 * z_m0 + h01 * z1 + h11 * z_m1;
 
-        // Calculate orientation based on path direction
+      // Calculate orientation based on path direction
       double yaw = 0.0;
       if (!smoothed.empty()) {
         const auto & prev = smoothed.back().position;
@@ -987,7 +987,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
         if (std::hypot(dx, dy) > 1e-6) {
           yaw = std::atan2(dy, dx);
 
-            // Smooth yaw transitions
+          // Smooth yaw transitions
           tf2::Quaternion prev_q;
           tf2::fromMsg(smoothed.back().orientation, prev_q);
           double pr, pp, prev_yaw;
@@ -1005,7 +1005,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
             yaw = prev_yaw + (dyaw > 0 ? max_yaw_step : -max_yaw_step);
           }
         } else {
-            // Keep previous orientation if no significant movement
+          // Keep previous orientation if no significant movement
           tf2::Quaternion prev_q;
           tf2::fromMsg(smoothed.back().orientation, prev_q);
           double pr, pp;
@@ -1017,19 +1017,19 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
       q.setRPY(0.0, 0.0, yaw);
       sample.orientation = tf2::toMsg(q);
 
-        // Avoid adding points too close
+      // Avoid adding points too close
       const auto & last_pos = smoothed.back().position;
       if (std::hypot(sample.position.x - last_pos.x,
-                       sample.position.y - last_pos.y) >= spacing_)
+                     sample.position.y - last_pos.y) >= spacing_)
       {
         smoothed.push_back(sample);
       }
     }
 
-      // Add the next raw waypoint with corrected orientation
+    // Add the next raw waypoint with corrected orientation
     geometry_msgs::msg::Pose next_pose = input_path[i + 1];
 
-      // Calculate orientation for the waypoint based on path direction
+    // Calculate orientation for the waypoint based on path direction
     if (!smoothed.empty()) {
       const auto & prev = smoothed.back().position;
       double dx = next_pose.position.x - prev.x;
@@ -1045,11 +1045,11 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
     smoothed.push_back(next_pose);
   }
 
-    // Ensure the final `preserve_n` points have the goal orientation
+  // Ensure the final `preserve_n` points have the goal orientation
   tf2::Quaternion goal_orientation;
   tf2::fromMsg(input_path.back().orientation, goal_orientation);
 
-    // Apply goal orientation to the last preserve_n points
+  // Apply goal orientation to the last preserve_n points
   size_t start_preserve = smoothed.size() > preserve_n ? smoothed.size() - preserve_n : 0;
   for (size_t i = start_preserve; i < smoothed.size(); ++i) {
     smoothed[i].orientation = tf2::toMsg(goal_orientation);
@@ -1058,8 +1058,8 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
     smoothed.back().orientation = tf2::toMsg(goal_orientation);
   }
   RCLCPP_DEBUG(get_node()->get_logger(),
-                 "Smoothed path: %zu -> %zu points (preserved %zu final orientations)",
-                 input_path.size(), smoothed.size(), preserve_n);
+               "Smoothed path: %zu -> %zu points (preserved %zu final orientations)",
+               input_path.size(), smoothed.size(), preserve_n);
 
   return smoothed;
 }

--- a/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
+++ b/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
@@ -198,7 +198,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
   for (int iter = 0; iter < max_iters_; ++iter) {
         // adaptive goal bias: increase bias if a candidate path exists, else grow modestly
     double adaptive_goal_bias = goal_bias_;
-   
+
     if (best_goal_node) {
       adaptive_goal_bias = std::min(0.9, goal_bias_ + 0.15 * (iter / 100.0));
     } else {
@@ -441,7 +441,7 @@ double GridMapRRTStarPlanner::distance(
   map.getPosition(a, pa);
   map.getPosition(b, pb);
 
-  return std::hypot(pb.x() - pa.x(), pb.y() - pa.y()); 
+  return std::hypot(pb.x() - pa.x(), pb.y() - pa.y());
 }
 
 // Replace previous implementation: trim path by removing waypoints behind or already passed by the robot
@@ -1043,9 +1043,9 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
   for (size_t i = start_preserve; i < smoothed.size(); ++i) {
     smoothed[i].orientation = tf2::toMsg(goal_orientation);
   }
-if (!smoothed.empty()) {
+  if (!smoothed.empty()) {
     smoothed.back().orientation = tf2::toMsg(goal_orientation);
-}
+  }
   RCLCPP_DEBUG(get_node()->get_logger(),
                  "Smoothed path: %zu -> %zu points (preserved %zu final orientations)",
                  input_path.size(), smoothed.size(), preserve_n);

--- a/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
+++ b/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
@@ -1,3 +1,22 @@
+// Copyright 2025 Intelligent Robotics Lab
+//
+// This file is part of the project Easy Navigation (EasyNav in short)
+// licensed under the GNU General Public License v3.0.
+// See <http://www.gnu.org/licenses/> for details.
+//
+// Easy Navigation program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 #include <cmath>
 #include <limits>
 #include <sstream>
@@ -15,6 +34,9 @@
 #include "easynav_gridmap_rrtstar_planner/KDTree.hpp"
 #include "tf2/LinearMath/Quaternion.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "visualization_msgs/msg/marker.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
+
 namespace easynav
 {
 grid_map::Index GridMapRRTStarPlanner::random_index(
@@ -48,10 +70,10 @@ GridMapRRTStarPlanner::GridMapRRTStarPlanner()
     [](const nav_msgs::msg::Path & path)
     {
       std::ostringstream ret;
-      ret           << "Path with " << path.poses.size() << " poses, length "
-                    << compute_path_length(path) << " m.";
+      ret     << "Path with " << path.poses.size() << " poses, length "
+              << compute_path_length(path) << " m.";
       return ret.str();
-            });
+        });
 }
 
 std::expected<void, std::string> GridMapRRTStarPlanner::on_initialize()
@@ -67,6 +89,8 @@ std::expected<void, std::string> GridMapRRTStarPlanner::on_initialize()
   node->declare_parameter<double>(plugin_name + ".goal_threshold", 0.5);
   node->declare_parameter<int>(plugin_name + ".kdtree_rebuild_interval", 800);
   node->declare_parameter<double>(plugin_name + ".spacing", 0.2);
+  node->declare_parameter<double>(plugin_name + ".max_lateral_deviation", 0.5);
+  node->declare_parameter<int>(plugin_name + ".final_poses_with_goal_orientation", 2);
 
   node->get_parameter(plugin_name + ".max_allowed_slope_deg", max_allowed_slope_deg_);
   node->get_parameter(plugin_name + ".max_iters", max_iters_);
@@ -76,12 +100,24 @@ std::expected<void, std::string> GridMapRRTStarPlanner::on_initialize()
   node->get_parameter(plugin_name + ".goal_threshold", goal_threshold_);
   node->get_parameter(plugin_name + ".kdtree_rebuild_interval", kdtree_rebuild_interval_);
   node->get_parameter(plugin_name + ".spacing", spacing_);
+  node->get_parameter(plugin_name + ".max_lateral_deviation", max_lateral_deviation_);
+  node->get_parameter(plugin_name + ".final_poses_with_goal_orientation",
+      final_poses_with_goal_orientation_);
 
   max_allowed_slope_ = max_allowed_slope_deg_ * M_PI / 180.0;
 
   path_pub_ = node->create_publisher<nav_msgs::msg::Path>("planner/path", 10);
+  marker_pub_ = node->create_publisher<visualization_msgs::msg::MarkerArray>("planner/marker", 10);
 
   node->get_logger().set_level(rclcpp::Logger::Level::Debug);
+
+  last_goal_pose_.position.x = 0.0;
+  last_goal_pose_.position.y = 0.0;
+  last_goal_pose_.position.z = 0.0;
+  last_goal_pose_.orientation.x = 0.0;
+  last_goal_pose_.orientation.y = 0.0;
+  last_goal_pose_.orientation.z = 0.0;
+  last_goal_pose_.orientation.w = 1.0;
 
   return {};
 }
@@ -92,31 +128,31 @@ grid_map::Index GridMapRRTStarPlanner::steer(
   const grid_map::Index & to)
 {
 
-        // Convert indices to continuous map positions
+    // Convert indices to continuous map positions
   grid_map::Position p_from, p_to;
   map.getPosition(from, p_from);
   map.getPosition(to, p_to);
 
-        // Compute vector from 'from' to 'to' and its Euclidean distance
+    // Compute vector from 'from' to 'to' and its Euclidean distance
   double dx = p_to.x() - p_from.x();
   double dy = p_to.y() - p_from.y();
   double dist = std::hypot(dx, dy);
 
   grid_map::Position p_new;
   if (dist <= step_size_) {
-            // Target is within one step: move directly to it
+      // Target is within one step: move directly to it
     p_new = p_to;
   } else {
-            // Move along the line by 'step_size_' toward target
+      // Move along the line by 'step_size_' toward target
     double ratio = step_size_ / dist;
     p_new = grid_map::Position(p_from.x() + dx * ratio,
-                                       p_from.y() + dy * ratio);
+                                 p_from.y() + dy * ratio);
   }
 
-        // Convert continuous position back to map index
+    // Convert continuous position back to map index
   grid_map::Index new_idx;
   if (!map.getIndex(p_new, new_idx)) {
-            // New position is outside map bounds
+      // New position is outside map bounds
     return grid_map::Index(-1, -1);
   }
 
@@ -129,15 +165,23 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
   const geometry_msgs::msg::Pose & goal)
 {
   std::vector<std::shared_ptr<RRTNode>> tree;
-  std::mt19937 rng(std::random_device{}());
+  static uint32_t seed_counter = 0;
+  std::mt19937 rng(seed_counter++);
   std::uniform_real_distribution<double> prob_dist(0.0, 1.0);
 
   grid_map::Index start_idx, goal_idx;
   if (!map.getIndex(grid_map::Position(start.position.x, start.position.y), start_idx) ||
     !map.getIndex(grid_map::Position(goal.position.x, goal.position.y), goal_idx))
   {
-    throw std::runtime_error("Start or goal position is outside map bounds");
+    RCLCPP_WARN(get_node()->get_logger(), "Start or goal position is outside map bounds");
+    return {};
   }
+
+    // get robot yaw from the start pose for forward-biased sampling
+  tf2::Quaternion robot_q;
+  tf2::fromMsg(start.orientation, robot_q);
+  double robot_roll, robot_pitch, robot_yaw;
+  tf2::Matrix3x3(robot_q).getRPY(robot_roll, robot_pitch, robot_yaw);
 
   auto root = std::make_shared<RRTNode>();
   root->index = start_idx;
@@ -147,8 +191,32 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
   std::shared_ptr<RRTNode> best_goal_node = nullptr;
   double best_goal_cost = std::numeric_limits<double>::max();
 
+  int iterations_without_improvement = 0;
+  const int max_no_improvement = 500;
+  const int min_iterations = max_iters_ / 2;
+
   for (int iter = 0; iter < max_iters_; ++iter) {
-    grid_map::Index rand_idx = (prob_dist(rng) < goal_bias_) ? goal_idx : random_index(map, rng);
+        // adaptive goal bias: increase bias if a candidate path exists, else grow modestly
+    double adaptive_goal_bias = goal_bias_;
+   
+    if (best_goal_node) {
+      adaptive_goal_bias = std::min(0.9, goal_bias_ + 0.15 * (iter / 100.0));
+    } else {
+      adaptive_goal_bias = std::min(0.6, goal_bias_ * 2.0);
+    }
+
+    grid_map::Index rand_idx;
+    if (prob_dist(rng) < adaptive_goal_bias) {
+      rand_idx = goal_idx;
+    } else {
+            // early iterations: bias samples forward relative to robot heading, otherwise sample uniformly
+      if (iter < 100 && tree.size() < 50) {
+        rand_idx = biased_random_index(map, start, robot_yaw, rng);
+      } else {
+        rand_idx = random_index(map, rng);
+      }
+    }
+
     auto nearest = find_nearest(tree, rand_idx, map);
     if (!nearest) {
       continue;
@@ -159,14 +227,21 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       continue;
     }
 
-    if (std::any_of(tree.begin(), tree.end(),
-      [&new_idx](const std::shared_ptr<RRTNode> & node)
-      {
-        return (node->index == new_idx).all();
-                            }))
-    {
-      continue;
+        // skip exact duplicates and very close nodes when tree is large
+    bool duplicate = false;
+    for (const auto & node : tree) {
+      if ((node->index == new_idx).all()) {
+        duplicate = true;
+        break;
+      }
+      if (tree.size() > 500 && distance(map, node->index, new_idx) < 0.1) {
+        duplicate = true;
+        break;
+      }
     }
+    if (duplicate) {continue;}
+
+        // compute full traversal cost for the new edge and skip infeasible edges
     double edge_cost = traversal_cost(map, nearest->index, new_idx);
     if (!std::isfinite(edge_cost)) {
       continue;
@@ -177,13 +252,30 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
     new_node->cost = nearest->cost + edge_cost;
     new_node->parent = nearest;
 
-            // RRT* optimization: try to choose a better parent from nearby nodes
-    double rewire_radius_ = 2.0;
-    for (const auto & near_node : tree) {
-      if (distance(map, near_node->index, new_idx) > rewire_radius_) {
-        continue;
-      }
+        // collect nearby nodes for potential rewiring using a dynamic radius
+    std::vector<std::shared_ptr<RRTNode>> nearby_nodes;
+    double search_radius = std::min(neighbor_radius_,
+                                       neighbor_radius_ *
+        std::sqrt(std::log(tree.size()) / tree.size()));
 
+    for (const auto & near_node : tree) {
+      double dist = distance(map, near_node->index, new_idx);
+      if (dist <= search_radius) {
+        nearby_nodes.push_back(near_node);
+      }
+    }
+
+        // limit number of neighbors considered, keeping closest ones
+    if (nearby_nodes.size() > 8) {
+      std::nth_element(nearby_nodes.begin(), nearby_nodes.begin() + 15, nearby_nodes.end(),
+        [&](const auto & a, const auto & b) {
+          return distance(map, a->index, new_idx) < distance(map, b->index, new_idx);
+                           });
+      nearby_nodes.resize(8);
+    }
+
+        // choose the best parent among nearby nodes to minimize cost
+    for (const auto & near_node : nearby_nodes) {
       double cost = traversal_cost(map, near_node->index, new_idx);
       if (!std::isfinite(cost)) {
         continue;
@@ -198,12 +290,9 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
 
     tree.push_back(new_node);
 
-            // Rewiring: try to improve costs of nearby existing nodes
-    for (auto & near_node : tree) {
-      if (near_node == new_node) {
-        continue;
-      }
-      if (distance(map, new_idx, near_node->index) > rewire_radius_) {
+        // try to rewire nearby nodes through the new node if it lowers their cost
+    for (auto & near_node : nearby_nodes) {
+      if (near_node == new_node || near_node == root) {
         continue;
       }
 
@@ -213,29 +302,118 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       }
 
       double total = new_node->cost + cost;
-      if (total < near_node->cost) {
+      if (total < near_node->cost - 0.01) {        // small threshold to avoid oscillation
         near_node->cost = total;
         near_node->parent = new_node;
       }
     }
 
-            // Check if new node is close enough to goal
-    if (distance(map, new_idx, goal_idx) < goal_threshold_) {
+        // check proximity to goal and update best solution if improved
+    double dist_to_goal = distance(map, new_idx, goal_idx);
+    if (dist_to_goal < goal_threshold_) {
       double goal_cost = traversal_cost(map, new_idx, goal_idx);
       if (std::isfinite(goal_cost)) {
         double total = new_node->cost + goal_cost;
         if (total < best_goal_cost) {
           best_goal_node = new_node;
           best_goal_cost = total;
+          iterations_without_improvement = 0;
+
+          RCLCPP_DEBUG(get_node()->get_logger(),
+                               "New best goal found at iteration %d with cost %.2f (dist: %.2f)",
+                               iter, best_goal_cost, dist_to_goal);
+
+                    // adaptive early termination: evaluate path efficiency against direct distance
+          if (iter > min_iterations && best_goal_node) {
+            double direct_distance = distance(map, start_idx, goal_idx);
+            double path_efficiency = best_goal_cost / direct_distance;
+
+            if (path_efficiency < 1.3 && iter > 2000) {
+              RCLCPP_DEBUG(get_node()->get_logger(),
+                                       "Early termination: efficient path found (%.1f%% of direct) at iter %d",
+                                       path_efficiency * 100, iter);
+              break;
+            }
+
+            if (path_efficiency < 1.1 && iter > 1000) {
+              RCLCPP_DEBUG(get_node()->get_logger(),
+                                       "Very efficient path found (%.1f%%), early exit at iter %d",
+                                       path_efficiency * 100, iter);
+              break;
+            }
+          }
+        } else {
+          iterations_without_improvement++;
         }
       }
+    } else {
+      iterations_without_improvement++;
+    }
+
+        // adaptive termination when no improvement for many iterations, scaled by tree size
+    int max_no_improvement_adaptive = max_no_improvement;
+    if (tree.size() > 1000) {max_no_improvement_adaptive = 50;}
+    if (tree.size() > 2000) {max_no_improvement_adaptive = 30;}
+
+    if (iterations_without_improvement > max_no_improvement_adaptive && best_goal_node) {
+      RCLCPP_DEBUG(get_node()->get_logger(),
+                       "No improvement termination at iteration %d (tree size: %zu)",
+                       iter, tree.size());
+      break;
     }
   }
 
-  auto raw_path = extract_path(best_goal_node, map, goal);
-  raw_path = smooth_path(raw_path, 5);
+  if (!best_goal_node) {
+    RCLCPP_WARN(get_node()->get_logger(), "No path found to goal after %d iterations", max_iters_);
+    return {};
+  }
 
+  auto raw_path = extract_path(best_goal_node, map, goal);
+
+  if (raw_path.empty()) {
+    RCLCPP_WARN(get_node()->get_logger(), "Extracted path is empty");
+    return {};
+  }
+
+    // apply conservative smoothing to the raw path
+  raw_path = smooth_path(raw_path, 4);
+
+  RCLCPP_DEBUG(get_node()->get_logger(),
+                 "Generated RRT* path with %zu points, cost %.2f, tree size: %zu",
+                 raw_path.size(), best_goal_cost, tree.size());
+
+  new_path_cost_ = best_goal_cost;
   return raw_path;
+}
+
+
+grid_map::Index GridMapRRTStarPlanner::biased_random_index(
+  const grid_map::GridMap & map,
+  const geometry_msgs::msg::Pose & robot_pose,
+  double robot_yaw,
+  std::mt19937 & rng)
+{
+    // Generate samples biased forward relative to the robot heading.
+    // Angle in ±60° in front, distance between 1 and 5 meters.
+  std::uniform_real_distribution<double> angle_dist(-M_PI / 3, M_PI / 3);
+  std::uniform_real_distribution<double> dist_dist(1.0, 5.0);
+
+  double bias_angle = robot_yaw + angle_dist(rng);
+  double bias_distance = dist_dist(rng);
+
+    // Compute biased target position in world coordinates
+  double target_x = robot_pose.position.x + bias_distance * std::cos(bias_angle);
+  double target_y = robot_pose.position.y + bias_distance * std::sin(bias_angle);
+
+  grid_map::Index biased_idx;
+  grid_map::Position target_pos(target_x, target_y);
+
+    // If biased point is inside the map, return its index, otherwise fall back
+  if (map.getIndex(target_pos, biased_idx)) {
+    return biased_idx;
+  } else {
+    return random_index(map, rng);
+  }
 }
 
 std::shared_ptr<RRTNode> GridMapRRTStarPlanner::find_nearest(
@@ -247,11 +425,11 @@ std::shared_ptr<RRTNode> GridMapRRTStarPlanner::find_nearest(
     return nullptr;
   }
 
+    // Return the node in 'tree' with minimum Euclidean distance to 'target'
   return *std::min_element(tree.begin(), tree.end(),
-           [&](const auto & a, const auto & b)
-           {
+           [&](const auto & a, const auto & b) {
              return distance(map, a->index, target) < distance(map, b->index, target);
-                                 });
+                             });
 }
 
 double GridMapRRTStarPlanner::distance(
@@ -262,7 +440,63 @@ double GridMapRRTStarPlanner::distance(
   grid_map::Position pa, pb;
   map.getPosition(a, pa);
   map.getPosition(b, pb);
-  return std::hypot(pb.x() - pa.x(), pb.y() - pa.y());
+
+  return std::hypot(pb.x() - pa.x(), pb.y() - pa.y()); 
+}
+
+// Replace previous implementation: trim path by removing waypoints behind or already passed by the robot
+nav_msgs::msg::Path GridMapRRTStarPlanner::trim_path_from_robot(
+  const nav_msgs::msg::Path & path,
+  const geometry_msgs::msg::Pose & robot_pose) const
+{
+  nav_msgs::msg::Path trimmed_path = path;
+
+  if (path.poses.size() < 2) {
+    return trimmed_path;
+  }
+
+  const double trim_distance = 1.0;   // meters: threshold to consider a waypoint "passed"
+  size_t closest_index = 0;
+  double min_distance = std::numeric_limits<double>::max();
+
+    // Find the closest waypoint to the robot
+  for (size_t i = 0; i < path.poses.size(); ++i) {
+    const auto & wp = path.poses[i].pose.position;
+    const auto & rp = robot_pose.position;
+    double d = std::hypot(wp.x - rp.x, wp.y - rp.y);
+    if (d < min_distance) {
+      min_distance = d;
+      closest_index = i;
+    }
+  }
+
+    // Identify previous waypoints that are very close (already visited)
+  size_t start_index = closest_index;
+  for (size_t i = 0; i <= closest_index; ++i) {
+    const auto & wp = path.poses[i].pose.position;
+    const auto & rp = robot_pose.position;
+    double d = std::hypot(wp.x - rp.x, wp.y - rp.y);
+    if (d < trim_distance) {
+      start_index = i + 1;       // mark for removal
+    } else {
+      break;
+    }
+  }
+
+    // Ensure we keep at least the closest waypoint
+  if (start_index > closest_index) {
+    start_index = closest_index;
+  }
+
+    // Erase the earlier segment only if enough waypoints remain after trimming
+  if (start_index > 0 && (path.poses.size() - start_index) >= 3) {
+    trimmed_path.poses.erase(trimmed_path.poses.begin(), trimmed_path.poses.begin() + start_index);
+    RCLCPP_DEBUG(get_node()->get_logger(),
+                     "Path trimmed: removed %zu waypoints, %zu remaining (closest at %.2fm)",
+                     start_index, trimmed_path.poses.size(), min_distance);
+  }
+
+  return trimmed_path;
 }
 
 std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
@@ -270,20 +504,19 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
   const grid_map::GridMap & map,
   const geometry_msgs::msg::Pose & goal)
 {
-        // Collect nodes from goal back to start by following parent links
   std::vector<std::shared_ptr<RRTNode>> nodes;
   nodes.reserve(100);
 
+    // collect nodes from the RRT tree back to the root
   for (auto current = goal_node; current; current = current->parent) {
     nodes.push_back(current);
   }
-        // Reverse to get path from start to goal
   std::reverse(nodes.begin(), nodes.end());
 
-        // Convert RRT nodes to ROS poses
   std::vector<geometry_msgs::msg::Pose> path;
   path.reserve(nodes.size());
 
+    // convert tree nodes to basic poses (no smoothing here)
   for (size_t i = 0; i < nodes.size(); ++i) {
     const auto & node = nodes[i];
     grid_map::Position pos;
@@ -292,38 +525,83 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
     geometry_msgs::msg::Pose pose;
     pose.position.x = pos.x();
     pose.position.y = pos.y();
-    pose.position.z = map.at("elevation", node->index);         // Set z using elevation layer
+    pose.position.z = map.at("elevation", node->index);
 
-            // Compute orientation if there is a next node
-    if (i + 1 < nodes.size()) {
-      grid_map::Position next_pos;
-      map.getPosition(nodes[i + 1]->index, next_pos);
-
-      double dx = next_pos.x() - pos.x();
-      double dy = next_pos.y() - pos.y();
-      double yaw = std::atan2(dy, dx);
-
-      tf2::Quaternion q;
-      q.setRPY(0, 0, yaw);
-      pose.orientation = tf2::toMsg(q);
-    }
+        // DEFAULT ORIENTATION: neutral (facing along x-axis)
+    tf2::Quaternion q;
+    q.setRPY(0, 0, 0);
+    pose.orientation = tf2::toMsg(q);
 
     path.push_back(pose);
   }
 
+    // for the final raw waypoint, apply the goal orientation
   if (!path.empty()) {
     path.back().orientation = goal.orientation;
   }
 
+  RCLCPP_DEBUG(get_node()->get_logger(),
+                 "Path extracted with %zu raw RRT* nodes (no smoothing)", path.size());
+
   return path;
+}
+
+double GridMapRRTStarPlanner::calculate_lateral_distance_to_path(
+  const nav_msgs::msg::Path & path,
+  const geometry_msgs::msg::Pose & robot_pose) const
+{
+  if (path.poses.size() < 2) {
+    return 0.0;
+  }
+
+  double min_distance = std::numeric_limits<double>::max();
+
+    // Find the closest point on any path segment to the robot
+  for (size_t i = 0; i < path.poses.size() - 1; ++i) {
+    const auto & p1 = path.poses[i].pose.position;
+    const auto & p2 = path.poses[i + 1].pose.position;
+    const auto & rp = robot_pose.position;
+
+        // Project robot position onto the vector p1->p2 and clamp to the segment
+    double vx = p2.x - p1.x;
+    double vy = p2.y - p1.y;
+    double wx = rp.x - p1.x;
+    double wy = rp.y - p1.y;
+
+    double dot = wx * vx + wy * vy;
+    double len_sq = vx * vx + vy * vy;
+
+    if (len_sq < 1e-6) {
+            // degenerate segment, skip
+      continue;
+    }
+
+    double t = dot / len_sq;
+    double cx, cy;
+    if (t <= 0.0) {
+      cx = p1.x;
+      cy = p1.y;
+    } else if (t >= 1.0) {
+      cx = p2.x;
+      cy = p2.y;
+    } else {
+      cx = p1.x + t * vx;
+      cy = p1.y + t * vy;
+    }
+
+    double d = std::hypot(rp.x - cx, rp.y - cy);
+    min_distance = std::min(min_distance, d);
+  }
+
+  return (min_distance == std::numeric_limits<double>::max()) ? 0.0 : min_distance;
 }
 
 double GridMapRRTStarPlanner::traversal_cost(
   const grid_map::GridMap & map,
-  const grid_map::Index & to,
-  const grid_map::Index & from)
+  const grid_map::Index & from,
+  const grid_map::Index & to)
 {
-        // Use a unique key (based on flattened indices) to identify the edge.
+    // Use a unique key (based on flattened indices) to identify the edge.
   const uint32_t width = static_cast<uint32_t>(map.getSize()[0]);
   const uint64_t key = edge_key(flat_index(from, width), flat_index(to, width));
 
@@ -350,15 +628,15 @@ double GridMapRRTStarPlanner::traversal_cost(
   double dz = z2 - z1;
   double horizontal_dist = std::hypot(dx, dy);
 
-        // Flat surface: cost = horizontal distance
+    // Flat surface: cost = horizontal distance
   if (std::abs(dz) < 1e-3) {
     return cost_cache_[key] = horizontal_dist;
   }
 
-        // Calculate slope
+    // Calculate slope
   double slope_rad = std::atan2(std::abs(dz), horizontal_dist);
 
-        // Reject edges with slope exceeding maximum allowed
+    // Reject edges with slope exceeding maximum allowed
   if (slope_rad > max_allowed_slope_) {
     return std::numeric_limits<double>::infinity();
   }
@@ -371,6 +649,7 @@ double GridMapRRTStarPlanner::traversal_cost(
 
   return cost_cache_[key] = final_cost;
 }
+
 void GridMapRRTStarPlanner::clear_cost_cache()
 {
   cost_cache_.clear();
@@ -389,20 +668,37 @@ uint64_t GridMapRRTStarPlanner::edge_key(uint32_t a_flat, uint32_t b_flat)
   return (static_cast<uint64_t>(a_flat) << 32) | b_flat;
 }
 
+
+bool GridMapRRTStarPlanner::check_goal_changed(const geometry_msgs::msg::Pose & goal_pose)
+{
+    // tolerance used for comparing goal positions
+  const double tolerance = goal_threshold_;
+
+    // check if the goal has changed significantly
+  bool goal_changed = (std::abs(goal_pose.position.x - last_goal_pose_.position.x) > tolerance ||
+    std::abs(goal_pose.position.y - last_goal_pose_.position.y) > tolerance ||
+    std::abs(goal_pose.position.z - last_goal_pose_.position.z) > tolerance);
+
+  if (goal_changed) {
+    last_goal_pose_ = goal_pose;     // update last known goal
+  }
+
+  return goal_changed;
+}
+
+// Replace entire update() function:
 void GridMapRRTStarPlanner::update(NavState & nav_state)
 {
-  current_path_.poses.clear();
-
+    // initial validations
   if (!nav_state.has("goals") || !nav_state.has("robot_pose") || !nav_state.has("map")) {
-    RCLCPP_DEBUG(
-                get_node()->get_logger(), "goals, robot_pose or map missing. Returning");
+    RCLCPP_DEBUG(get_node()->get_logger(), "goals, robot_pose or map missing. Returning");
     return;
   }
 
   const auto goals = nav_state.get<nav_msgs::msg::Goals>("goals");
   if (goals.goals.empty()) {
-    RCLCPP_DEBUG(
-                get_node()->get_logger(), "goals empty. Returning empty path");
+    RCLCPP_DEBUG(get_node()->get_logger(), "goals empty. Returning empty path");
+    current_path_.poses.clear();
     nav_state.set("path", current_path_);
     return;
   }
@@ -411,12 +707,60 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
   const auto & goal_pose = goals.goals.front().pose;
   const auto & map = nav_state.get<grid_map::GridMap>("map");
 
-  clear_cost_cache();
-  kd_tree_ = std::make_unique<KDTree>();
+    // evaluate conditions once
+  bool goal_changed = check_goal_changed(goal_pose);
+  bool robot_deviated = false;
+  bool path_too_short = current_path_.poses.size() < 3;
+  double lateral_distance = 0.0;
 
-  auto new_poses = rrt_star(map, robot_pose.pose.pose, goal_pose);
+    // check robot deviation only if a path exists
+  if (!current_path_.poses.empty()) {
+    lateral_distance = calculate_lateral_distance_to_path(current_path_, robot_pose.pose.pose);
+    robot_deviated = (lateral_distance > max_lateral_deviation_);
 
-  if (!new_poses.empty()) {
+    if (robot_deviated) {
+      RCLCPP_INFO(get_node()->get_logger(),
+                        "Robot deviated from path (%.2f m > %.2f m threshold), replanning",
+                        lateral_distance, max_lateral_deviation_);
+    } else {
+      RCLCPP_DEBUG(get_node()->get_logger(),
+                         "Robot deviation: %.2f m (within %.2f m threshold)",
+                         lateral_distance, max_lateral_deviation_);
+    }
+  }
+
+    // decide once whether to replan
+  bool needs_replan = goal_changed || robot_deviated || path_too_short;
+  bool needs_new_path = needs_replan || current_path_.poses.empty();
+
+    // perform actions based on decision
+  if (needs_replan) {
+    if (goal_changed) {
+      RCLCPP_INFO(get_node()->get_logger(), "New goal detected, regenerating path");
+      last_goal_pose_ = goal_pose;
+    } else if (robot_deviated) {
+      RCLCPP_INFO(get_node()->get_logger(), "Robot deviated, regenerating path");
+    } else if (path_too_short) {
+      RCLCPP_DEBUG(get_node()->get_logger(),
+                         "Path too short (%zu waypoints), regenerating",
+                         current_path_.poses.size());
+    }
+
+        // reset state for replanning
+    current_path_.poses.clear();
+    clear_cost_cache();
+    current_path_cost_ = std::numeric_limits<double>::max();
+    kd_tree_ = std::make_unique<KDTree>();
+  }
+
+    // generate a new path if needed
+  if (needs_new_path) {
+    auto new_poses = generate_new_path(map, robot_pose.pose.pose, goal_pose);
+    if (new_poses.empty()) {
+      RCLCPP_WARN(get_node()->get_logger(), "Failed to generate a new path");
+      return;
+    }
+
     nav_msgs::msg::Path new_path;
     new_path.header.stamp = get_node()->now();
     new_path.header.frame_id = goals.header.frame_id;
@@ -428,105 +772,283 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
       new_path.poses.push_back(ps);
     }
 
-    current_path_ = new_path;
-    nav_state.set("path", current_path_);
+        // accept or compare new path
+    if (needs_replan) {
+      current_path_ = new_path;
+      current_path_cost_ = new_path_cost_;
+      RCLCPP_DEBUG(get_node()->get_logger(),
+                         "Using new path: cost %.2f, length %.2f m",
+                         new_path_cost_, compute_path_length(new_path));
+    } else if (current_path_.poses.empty()) {
+      current_path_ = new_path;
+      current_path_cost_ = new_path_cost_;
+      RCLCPP_DEBUG(get_node()->get_logger(),
+                         "Using new path (no previous path): cost %.2f, length %.2f m",
+                         new_path_cost_, compute_path_length(new_path));
+    } else {
+      const double improvement_threshold = 5 * goal_threshold_;
 
-    if (path_pub_->get_subscription_count() > 0) {
-      path_pub_->publish(current_path_);
+      if (current_path_cost_ - new_path_cost_ > improvement_threshold) {
+        double cost_improvement = current_path_cost_ - new_path_cost_;
+        double old_cost = current_path_cost_;
+
+        current_path_ = new_path;
+        current_path_cost_ = new_path_cost_;
+
+        RCLCPP_DEBUG(get_node()->get_logger(),
+                             "Updated to better cost path: %.2f -> %.2f (improvement: %.2f)",
+                             old_cost, new_path_cost_, cost_improvement);
+      } else {
+        double cost_difference = new_path_cost_ - current_path_cost_;
+        RCLCPP_DEBUG(get_node()->get_logger(),
+                             "Keeping current path: cost %.2f < %.2f (difference: %.2f, threshold: %.2f)",
+                             current_path_cost_, new_path_cost_, cost_difference,
+            improvement_threshold);
+      }
     }
+  }
+
+    // apply trimming and publish
+  if (!current_path_.poses.empty()) {
+    size_t original_size = current_path_.poses.size();
+    current_path_ = trim_path_from_robot(current_path_, robot_pose.pose.pose);
+
+    if (current_path_.poses.size() != original_size) {
+      RCLCPP_DEBUG(get_node()->get_logger(),
+                         "Path trimmed: %zu -> %zu waypoints",
+                         original_size, current_path_.poses.size());
+    }
+  }
+
+  nav_state.set("path", current_path_);
+
+  if (path_pub_->get_subscription_count() > 0) {
+    path_pub_->publish(current_path_);
+  }
+
+  if (marker_pub_->get_subscription_count() > 0) {
+    publish_path_markers(current_path_);
   }
 }
 
+std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::generate_new_path(
+  const grid_map::GridMap & map,
+  const geometry_msgs::msg::Pose & robot_pose,
+  const geometry_msgs::msg::Pose & goal_pose)
+{
+  std::vector<geometry_msgs::msg::Pose> new_poses;
+
+    // ensure goal is inside map bounds
+  grid_map::Index goal_idx;
+  if (!map.getIndex(grid_map::Position(goal_pose.position.x, goal_pose.position.y), goal_idx)) {
+    RCLCPP_WARN(get_node()->get_logger(), "Goal is outside the map bounds");
+    return new_poses;
+  }
+
+    // always plan from robot pose for consistency
+  RCLCPP_DEBUG(get_node()->get_logger(), "Generating new path from robot pose");
+  new_poses = rrt_star(map, robot_pose, goal_pose);
+
+  return new_poses;
+}
+
+void GridMapRRTStarPlanner::publish_path_markers(const nav_msgs::msg::Path & path)
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+
+    // clear previous markers
+  visualization_msgs::msg::Marker clear;
+  clear.action = visualization_msgs::msg::Marker::DELETEALL;
+  marker_array.markers.push_back(clear);
+
+    // create markers for each path pose
+  int id = 0;
+  for (const auto & pose_stamped : path.poses) {
+    visualization_msgs::msg::Marker marker;
+    marker.header = path.header;
+    marker.ns = "rrt_star_path";
+    marker.id = id++;
+    marker.type = visualization_msgs::msg::Marker::ARROW;
+    marker.action = visualization_msgs::msg::Marker::ADD;
+
+        // set marker pose
+    marker.pose = pose_stamped.pose;
+
+        // set marker scale
+    marker.scale.x = 0.3;      // arrow length
+    marker.scale.y = 0.05;     // arrow thickness
+    marker.scale.z = 0.05;
+
+        // set marker color
+    marker.color.r = 0.1f;
+    marker.color.g = 0.1f;
+    marker.color.b = 1.0f;
+    marker.color.a = 1.0f;
+
+    marker_array.markers.push_back(marker);
+  }
+
+    // publish markers
+  marker_pub_->publish(marker_array);
+}
 std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
   const std::vector<geometry_msgs::msg::Pose> & input_path,
   int interpolation_points_per_segment)
 {
-  std::vector<geometry_msgs::msg::Pose> smoothed;
-
-  if (input_path.size() < 4) {
+    // Return the input path if it's too short to smooth
+  if (input_path.size() < 3) {
     return input_path;
   }
 
-  for (size_t i = 1; i < input_path.size() - 2; ++i) {
-    const auto & p0 = input_path[i - 1].position;
-    const auto & p1 = input_path[i].position;
-    const auto & p2 = input_path[i + 1].position;
-    const auto & p3 = input_path[i + 2].position;
+  std::vector<geometry_msgs::msg::Pose> smoothed;
+  const size_t N = input_path.size();
+  const size_t preserve_n = std::max(1, final_poses_with_goal_orientation_);
+  const double max_yaw_step = M_PI / 8.0;
 
-    for (int j = 0; j < interpolation_points_per_segment; ++j) {
-      double t = static_cast<double>(j) / interpolation_points_per_segment;
-      geometry_msgs::msg::Pose pose;
+    // Precompute positions and tangents
+  std::vector<grid_map::Position> pts(N);
+  std::vector<double> z_values(N);
+  for (size_t i = 0; i < N; ++i) {
+    pts[i] = {input_path[i].position.x, input_path[i].position.y};
+    z_values[i] = input_path[i].position.z;
+  }
 
-                // Catmull–Rom spline
-      pose.position.x = 0.5 * ((2 * p1.x) +
-        (-p0.x + p2.x) * t +
-        (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t * t +
-        (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t * t * t);
-
-      pose.position.y = 0.5 * ((2 * p1.y) +
-        (-p0.y + p2.y) * t +
-        (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t * t +
-        (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t * t * t);
-
-      pose.position.z = 0.5 * ((2 * p1.z) +
-        (-p0.z + p2.z) * t +
-        (2 * p0.z - 5 * p1.z + 4 * p2.z - p3.z) * t * t +
-        (-p0.z + 3 * p1.z - 3 * p2.z + p3.z) * t * t * t);
-
-      if (!smoothed.empty()) {
-        const auto & prev = smoothed.back().position;
-        double dx = pose.position.x - prev.x;
-        double dy = pose.position.y - prev.y;
-
-        if (std::hypot(dx, dy) > 1e-6) {
-          double yaw = std::atan2(dy, dx);
-          tf2::Quaternion q;
-          q.setRPY(0, 0, yaw);
-          pose.orientation = tf2::toMsg(q);
-        } else {
-          pose.orientation = smoothed.back().orientation;
-        }
+  auto compute_tangent = [&](size_t idx) -> grid_map::Position {
+      if (idx == 0) {
+        return 0.5 * (pts[1] - pts[0]);
+      } else if (idx + 1 >= N) {
+        return 0.5 * (pts[N - 1] - pts[N - 2]);
       } else {
-        double dx = p2.x - p1.x;
-        double dy = p2.y - p1.y;
-        double yaw = std::atan2(dy, dx);
-        tf2::Quaternion q;
-        q.setRPY(0, 0, yaw);
-        pose.orientation = tf2::toMsg(q);
+        return 0.5 * (pts[idx + 1] - pts[idx - 1]);
       }
+    };
 
-                // Avoid too much points, minimal spacing
-      if (!smoothed.empty()) {
-        const auto & prev = smoothed.back().position;
-        if (std::hypot(pose.position.x - prev.x,
-                                   pose.position.y - prev.y) < spacing_)
-        {
-          continue;
-        }
-      }
+  std::vector<grid_map::Position> tangents(N);
+  std::vector<double> z_tangents(N);
+  for (size_t i = 0; i < N; ++i) {
+    tangents[i] = compute_tangent(i);
+    z_tangents[i] = (i == 0) ? 0.5 * (z_values[1] - z_values[0]) :
+      (i + 1 >= N) ? 0.5 * (z_values[N - 1] - z_values[N - 2]) :
+      0.5 * (z_values[i + 1] - z_values[i - 1]);
+  }
 
-      smoothed.push_back(pose);
+    // Add the first point with corrected orientation
+  geometry_msgs::msg::Pose first_pose = input_path.front();
+
+    // Calculate orientation for the first point based on direction to second point
+  if (input_path.size() > 1) {
+    double dx = input_path[1].position.x - first_pose.position.x;
+    double dy = input_path[1].position.y - first_pose.position.y;
+    if (std::hypot(dx, dy) > 1e-6) {
+      double yaw = std::atan2(dy, dx);
+      tf2::Quaternion q;
+      q.setRPY(0.0, 0.0, yaw);
+      first_pose.orientation = tf2::toMsg(q);
     }
   }
 
-        // Add last original waypoint with correct orientation
-  if (!input_path.empty()) {
-    geometry_msgs::msg::Pose last = input_path.back();
+  smoothed.push_back(first_pose);
+
+    // Interpolate between points
+  for (size_t i = 0; i < N - 1; ++i) {
+    const auto & p0 = pts[i], & p1 = pts[i + 1];
+    const auto & m0 = tangents[i], & m1 = tangents[i + 1];
+    double z0 = z_values[i], z1 = z_values[i + 1];
+    double z_m0 = z_tangents[i], z_m1 = z_tangents[i + 1];
+
+    for (int s = 1; s <= interpolation_points_per_segment; ++s) {
+      double t = static_cast<double>(s) / (interpolation_points_per_segment + 1);
+      double t2 = t * t, t3 = t2 * t;
+
+            // Hermite interpolation
+      double h00 = 2.0 * t3 - 3.0 * t2 + 1.0;
+      double h10 = t3 - 2.0 * t2 + t;
+      double h01 = -2.0 * t3 + 3.0 * t2;
+      double h11 = t3 - t2;
+
+      geometry_msgs::msg::Pose sample;
+      sample.position.x = h00 * p0.x() + h10 * m0.x() + h01 * p1.x() + h11 * m1.x();
+      sample.position.y = h00 * p0.y() + h10 * m0.y() + h01 * p1.y() + h11 * m1.y();
+      sample.position.z = h00 * z0 + h10 * z_m0 + h01 * z1 + h11 * z_m1;
+
+            // Calculate orientation based on path direction
+      double yaw = 0.0;
+      if (!smoothed.empty()) {
+        const auto & prev = smoothed.back().position;
+        double dx = sample.position.x - prev.x;
+        double dy = sample.position.y - prev.y;
+        if (std::hypot(dx, dy) > 1e-6) {
+          yaw = std::atan2(dy, dx);
+
+                    // Smooth yaw transitions
+          tf2::Quaternion prev_q;
+          tf2::fromMsg(smoothed.back().orientation, prev_q);
+          double pr, pp, prev_yaw;
+          tf2::Matrix3x3(prev_q).getRPY(pr, pp, prev_yaw);
+
+          double dyaw = yaw - prev_yaw;
+          while (dyaw > M_PI) {dyaw -= 2.0 * M_PI;}
+          while (dyaw < -M_PI) {dyaw += 2.0 * M_PI;}
+
+          if (std::abs(dyaw) > max_yaw_step) {
+            yaw = prev_yaw + (dyaw > 0 ? max_yaw_step : -max_yaw_step);
+          }
+        } else {
+                    // Keep previous orientation if no significant movement
+          tf2::Quaternion prev_q;
+          tf2::fromMsg(smoothed.back().orientation, prev_q);
+          double pr, pp;
+          tf2::Matrix3x3(prev_q).getRPY(pr, pp, yaw);
+        }
+      }
+
+      tf2::Quaternion q;
+      q.setRPY(0.0, 0.0, yaw);
+      sample.orientation = tf2::toMsg(q);
+
+            // Avoid adding points too close
+      const auto & last_pos = smoothed.back().position;
+      if (std::hypot(sample.position.x - last_pos.x,
+                           sample.position.y - last_pos.y) >= spacing_)
+      {
+        smoothed.push_back(sample);
+      }
+    }
+
+        // Add the next raw waypoint with corrected orientation
+    geometry_msgs::msg::Pose next_pose = input_path[i + 1];
+
+        // Calculate orientation for the waypoint based on path direction
     if (!smoothed.empty()) {
       const auto & prev = smoothed.back().position;
-      double dx = last.position.x - prev.x;
-      double dy = last.position.y - prev.y;
+      double dx = next_pose.position.x - prev.x;
+      double dy = next_pose.position.y - prev.y;
       if (std::hypot(dx, dy) > 1e-6) {
         double yaw = std::atan2(dy, dx);
         tf2::Quaternion q;
-        q.setRPY(0, 0, yaw);
-        last.orientation = tf2::toMsg(q);
-      } else {
-        last.orientation = smoothed.back().orientation;
+        q.setRPY(0.0, 0.0, yaw);
+        next_pose.orientation = tf2::toMsg(q);
       }
     }
-    smoothed.push_back(last);
+
+    smoothed.push_back(next_pose);
   }
+
+    // Ensure the final `preserve_n` points have the goal orientation
+  tf2::Quaternion goal_orientation;
+  tf2::fromMsg(input_path.back().orientation, goal_orientation);
+
+    // Apply goal orientation to the last preserve_n points
+  size_t start_preserve = smoothed.size() > preserve_n ? smoothed.size() - preserve_n : 0;
+  for (size_t i = start_preserve; i < smoothed.size(); ++i) {
+    smoothed[i].orientation = tf2::toMsg(goal_orientation);
+  }
+if (!smoothed.empty()) {
+    smoothed.back().orientation = tf2::toMsg(goal_orientation);
+}
+  RCLCPP_DEBUG(get_node()->get_logger(),
+                 "Smoothed path: %zu -> %zu points (preserved %zu final orientations)",
+                 input_path.size(), smoothed.size(), preserve_n);
 
   return smoothed;
 }

--- a/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
+++ b/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/GridMapRRTStarPlanner.cpp
@@ -102,7 +102,7 @@ std::expected<void, std::string> GridMapRRTStarPlanner::on_initialize()
   node->get_parameter(plugin_name + ".spacing", spacing_);
   node->get_parameter(plugin_name + ".max_lateral_deviation", max_lateral_deviation_);
   node->get_parameter(plugin_name + ".final_poses_with_goal_orientation",
-      final_poses_with_goal_orientation_);
+                        final_poses_with_goal_orientation_);
 
   max_allowed_slope_ = max_allowed_slope_deg_ * M_PI / 180.0;
 
@@ -196,7 +196,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
   const int min_iterations = max_iters_ / 2;
 
   for (int iter = 0; iter < max_iters_; ++iter) {
-        // adaptive goal bias: increase bias if a candidate path exists, else grow modestly
+      // adaptive goal bias: increase bias if a candidate path exists, else grow modestly
     double adaptive_goal_bias = goal_bias_;
 
     if (best_goal_node) {
@@ -209,7 +209,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
     if (prob_dist(rng) < adaptive_goal_bias) {
       rand_idx = goal_idx;
     } else {
-            // early iterations: bias samples forward relative to robot heading, otherwise sample uniformly
+        // early iterations: bias samples forward relative to robot heading, otherwise sample uniformly
       if (iter < 100 && tree.size() < 50) {
         rand_idx = biased_random_index(map, start, robot_yaw, rng);
       } else {
@@ -227,7 +227,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       continue;
     }
 
-        // skip exact duplicates and very close nodes when tree is large
+      // skip exact duplicates and very close nodes when tree is large
     bool duplicate = false;
     for (const auto & node : tree) {
       if ((node->index == new_idx).all()) {
@@ -239,9 +239,11 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
         break;
       }
     }
-    if (duplicate) {continue;}
+    if (duplicate) {
+      continue;
+    }
 
-        // compute full traversal cost for the new edge and skip infeasible edges
+      // compute full traversal cost for the new edge and skip infeasible edges
     double edge_cost = traversal_cost(map, nearest->index, new_idx);
     if (!std::isfinite(edge_cost)) {
       continue;
@@ -252,11 +254,11 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
     new_node->cost = nearest->cost + edge_cost;
     new_node->parent = nearest;
 
-        // collect nearby nodes for potential rewiring using a dynamic radius
+      // collect nearby nodes for potential rewiring using a dynamic radius
     std::vector<std::shared_ptr<RRTNode>> nearby_nodes;
     double search_radius = std::min(neighbor_radius_,
-                                       neighbor_radius_ *
-        std::sqrt(std::log(tree.size()) / tree.size()));
+                                      neighbor_radius_ *
+                                          std::sqrt(std::log(tree.size()) / tree.size()));
 
     for (const auto & near_node : tree) {
       double dist = distance(map, near_node->index, new_idx);
@@ -265,16 +267,17 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       }
     }
 
-        // limit number of neighbors considered, keeping closest ones
+      // limit number of neighbors considered, keeping closest ones
     if (nearby_nodes.size() > 8) {
       std::nth_element(nearby_nodes.begin(), nearby_nodes.begin() + 15, nearby_nodes.end(),
-        [&](const auto & a, const auto & b) {
+        [&](const auto & a, const auto & b)
+        {
           return distance(map, a->index, new_idx) < distance(map, b->index, new_idx);
-                           });
+                         });
       nearby_nodes.resize(8);
     }
 
-        // choose the best parent among nearby nodes to minimize cost
+      // choose the best parent among nearby nodes to minimize cost
     for (const auto & near_node : nearby_nodes) {
       double cost = traversal_cost(map, near_node->index, new_idx);
       if (!std::isfinite(cost)) {
@@ -290,7 +293,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
 
     tree.push_back(new_node);
 
-        // try to rewire nearby nodes through the new node if it lowers their cost
+      // try to rewire nearby nodes through the new node if it lowers their cost
     for (auto & near_node : nearby_nodes) {
       if (near_node == new_node || near_node == root) {
         continue;
@@ -302,13 +305,13 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       }
 
       double total = new_node->cost + cost;
-      if (total < near_node->cost - 0.01) {        // small threshold to avoid oscillation
+      if (total < near_node->cost - 0.01) { // small threshold to avoid oscillation
         near_node->cost = total;
         near_node->parent = new_node;
       }
     }
 
-        // check proximity to goal and update best solution if improved
+      // check proximity to goal and update best solution if improved
     double dist_to_goal = distance(map, new_idx, goal_idx);
     if (dist_to_goal < goal_threshold_) {
       double goal_cost = traversal_cost(map, new_idx, goal_idx);
@@ -320,25 +323,25 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
           iterations_without_improvement = 0;
 
           RCLCPP_DEBUG(get_node()->get_logger(),
-                               "New best goal found at iteration %d with cost %.2f (dist: %.2f)",
-                               iter, best_goal_cost, dist_to_goal);
+                         "New best goal found at iteration %d with cost %.2f (dist: %.2f)",
+                         iter, best_goal_cost, dist_to_goal);
 
-                    // adaptive early termination: evaluate path efficiency against direct distance
+            // adaptive early termination: evaluate path efficiency against direct distance
           if (iter > min_iterations && best_goal_node) {
             double direct_distance = distance(map, start_idx, goal_idx);
             double path_efficiency = best_goal_cost / direct_distance;
 
             if (path_efficiency < 1.3 && iter > 2000) {
               RCLCPP_DEBUG(get_node()->get_logger(),
-                                       "Early termination: efficient path found (%.1f%% of direct) at iter %d",
-                                       path_efficiency * 100, iter);
+                             "Early termination: efficient path found (%.1f%% of direct) at iter %d",
+                             path_efficiency * 100, iter);
               break;
             }
 
             if (path_efficiency < 1.1 && iter > 1000) {
               RCLCPP_DEBUG(get_node()->get_logger(),
-                                       "Very efficient path found (%.1f%%), early exit at iter %d",
-                                       path_efficiency * 100, iter);
+                             "Very efficient path found (%.1f%%), early exit at iter %d",
+                             path_efficiency * 100, iter);
               break;
             }
           }
@@ -350,15 +353,19 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
       iterations_without_improvement++;
     }
 
-        // adaptive termination when no improvement for many iterations, scaled by tree size
+      // adaptive termination when no improvement for many iterations, scaled by tree size
     int max_no_improvement_adaptive = max_no_improvement;
-    if (tree.size() > 1000) {max_no_improvement_adaptive = 50;}
-    if (tree.size() > 2000) {max_no_improvement_adaptive = 30;}
+    if (tree.size() > 1000) {
+      max_no_improvement_adaptive = 50;
+    }
+    if (tree.size() > 2000) {
+      max_no_improvement_adaptive = 30;
+    }
 
     if (iterations_without_improvement > max_no_improvement_adaptive && best_goal_node) {
       RCLCPP_DEBUG(get_node()->get_logger(),
-                       "No improvement termination at iteration %d (tree size: %zu)",
-                       iter, tree.size());
+                     "No improvement termination at iteration %d (tree size: %zu)",
+                     iter, tree.size());
       break;
     }
   }
@@ -385,7 +392,6 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::rrt_star(
   new_path_cost_ = best_goal_cost;
   return raw_path;
 }
-
 
 grid_map::Index GridMapRRTStarPlanner::biased_random_index(
   const grid_map::GridMap & map,
@@ -427,7 +433,8 @@ std::shared_ptr<RRTNode> GridMapRRTStarPlanner::find_nearest(
 
     // Return the node in 'tree' with minimum Euclidean distance to 'target'
   return *std::min_element(tree.begin(), tree.end(),
-           [&](const auto & a, const auto & b) {
+           [&](const auto & a, const auto & b)
+           {
              return distance(map, a->index, target) < distance(map, b->index, target);
                              });
 }
@@ -444,7 +451,7 @@ double GridMapRRTStarPlanner::distance(
   return std::hypot(pb.x() - pa.x(), pb.y() - pa.y());
 }
 
-// Replace previous implementation: trim path by removing waypoints behind or already passed by the robot
+  // Replace previous implementation: trim path by removing waypoints behind or already passed by the robot
 nav_msgs::msg::Path GridMapRRTStarPlanner::trim_path_from_robot(
   const nav_msgs::msg::Path & path,
   const geometry_msgs::msg::Pose & robot_pose) const
@@ -477,7 +484,7 @@ nav_msgs::msg::Path GridMapRRTStarPlanner::trim_path_from_robot(
     const auto & rp = robot_pose.position;
     double d = std::hypot(wp.x - rp.x, wp.y - rp.y);
     if (d < trim_distance) {
-      start_index = i + 1;       // mark for removal
+      start_index = i + 1;   // mark for removal
     } else {
       break;
     }
@@ -492,8 +499,8 @@ nav_msgs::msg::Path GridMapRRTStarPlanner::trim_path_from_robot(
   if (start_index > 0 && (path.poses.size() - start_index) >= 3) {
     trimmed_path.poses.erase(trimmed_path.poses.begin(), trimmed_path.poses.begin() + start_index);
     RCLCPP_DEBUG(get_node()->get_logger(),
-                     "Path trimmed: removed %zu waypoints, %zu remaining (closest at %.2fm)",
-                     start_index, trimmed_path.poses.size(), min_distance);
+                   "Path trimmed: removed %zu waypoints, %zu remaining (closest at %.2fm)",
+                   start_index, trimmed_path.poses.size(), min_distance);
   }
 
   return trimmed_path;
@@ -527,7 +534,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::extract_path(
     pose.position.y = pos.y();
     pose.position.z = map.at("elevation", node->index);
 
-        // DEFAULT ORIENTATION: neutral (facing along x-axis)
+      // DEFAULT ORIENTATION: neutral (facing along x-axis)
     tf2::Quaternion q;
     q.setRPY(0, 0, 0);
     pose.orientation = tf2::toMsg(q);
@@ -562,7 +569,7 @@ double GridMapRRTStarPlanner::calculate_lateral_distance_to_path(
     const auto & p2 = path.poses[i + 1].pose.position;
     const auto & rp = robot_pose.position;
 
-        // Project robot position onto the vector p1->p2 and clamp to the segment
+      // Project robot position onto the vector p1->p2 and clamp to the segment
     double vx = p2.x - p1.x;
     double vy = p2.y - p1.y;
     double wx = rp.x - p1.x;
@@ -572,7 +579,7 @@ double GridMapRRTStarPlanner::calculate_lateral_distance_to_path(
     double len_sq = vx * vx + vy * vy;
 
     if (len_sq < 1e-6) {
-            // degenerate segment, skip
+        // degenerate segment, skip
       continue;
     }
 
@@ -668,7 +675,6 @@ uint64_t GridMapRRTStarPlanner::edge_key(uint32_t a_flat, uint32_t b_flat)
   return (static_cast<uint64_t>(a_flat) << 32) | b_flat;
 }
 
-
 bool GridMapRRTStarPlanner::check_goal_changed(const geometry_msgs::msg::Pose & goal_pose)
 {
     // tolerance used for comparing goal positions
@@ -680,13 +686,13 @@ bool GridMapRRTStarPlanner::check_goal_changed(const geometry_msgs::msg::Pose & 
     std::abs(goal_pose.position.z - last_goal_pose_.position.z) > tolerance);
 
   if (goal_changed) {
-    last_goal_pose_ = goal_pose;     // update last known goal
+    last_goal_pose_ = goal_pose;   // update last known goal
   }
 
   return goal_changed;
 }
 
-// Replace entire update() function:
+  // Replace entire update() function:
 void GridMapRRTStarPlanner::update(NavState & nav_state)
 {
     // initial validations
@@ -720,12 +726,12 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
 
     if (robot_deviated) {
       RCLCPP_INFO(get_node()->get_logger(),
-                        "Robot deviated from path (%.2f m > %.2f m threshold), replanning",
-                        lateral_distance, max_lateral_deviation_);
+                    "Robot deviated from path (%.2f m > %.2f m threshold), replanning",
+                    lateral_distance, max_lateral_deviation_);
     } else {
       RCLCPP_DEBUG(get_node()->get_logger(),
-                         "Robot deviation: %.2f m (within %.2f m threshold)",
-                         lateral_distance, max_lateral_deviation_);
+                     "Robot deviation: %.2f m (within %.2f m threshold)",
+                     lateral_distance, max_lateral_deviation_);
     }
   }
 
@@ -742,11 +748,11 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
       RCLCPP_INFO(get_node()->get_logger(), "Robot deviated, regenerating path");
     } else if (path_too_short) {
       RCLCPP_DEBUG(get_node()->get_logger(),
-                         "Path too short (%zu waypoints), regenerating",
-                         current_path_.poses.size());
+                     "Path too short (%zu waypoints), regenerating",
+                     current_path_.poses.size());
     }
 
-        // reset state for replanning
+      // reset state for replanning
     current_path_.poses.clear();
     clear_cost_cache();
     current_path_cost_ = std::numeric_limits<double>::max();
@@ -772,19 +778,19 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
       new_path.poses.push_back(ps);
     }
 
-        // accept or compare new path
+      // accept or compare new path
     if (needs_replan) {
       current_path_ = new_path;
       current_path_cost_ = new_path_cost_;
       RCLCPP_DEBUG(get_node()->get_logger(),
-                         "Using new path: cost %.2f, length %.2f m",
-                         new_path_cost_, compute_path_length(new_path));
+                     "Using new path: cost %.2f, length %.2f m",
+                     new_path_cost_, compute_path_length(new_path));
     } else if (current_path_.poses.empty()) {
       current_path_ = new_path;
       current_path_cost_ = new_path_cost_;
       RCLCPP_DEBUG(get_node()->get_logger(),
-                         "Using new path (no previous path): cost %.2f, length %.2f m",
-                         new_path_cost_, compute_path_length(new_path));
+                     "Using new path (no previous path): cost %.2f, length %.2f m",
+                     new_path_cost_, compute_path_length(new_path));
     } else {
       const double improvement_threshold = 5 * goal_threshold_;
 
@@ -796,14 +802,14 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
         current_path_cost_ = new_path_cost_;
 
         RCLCPP_DEBUG(get_node()->get_logger(),
-                             "Updated to better cost path: %.2f -> %.2f (improvement: %.2f)",
-                             old_cost, new_path_cost_, cost_improvement);
+                       "Updated to better cost path: %.2f -> %.2f (improvement: %.2f)",
+                       old_cost, new_path_cost_, cost_improvement);
       } else {
         double cost_difference = new_path_cost_ - current_path_cost_;
         RCLCPP_DEBUG(get_node()->get_logger(),
-                             "Keeping current path: cost %.2f < %.2f (difference: %.2f, threshold: %.2f)",
-                             current_path_cost_, new_path_cost_, cost_difference,
-            improvement_threshold);
+                       "Keeping current path: cost %.2f < %.2f (difference: %.2f, threshold: %.2f)",
+                       current_path_cost_, new_path_cost_, cost_difference,
+                       improvement_threshold);
       }
     }
   }
@@ -815,8 +821,8 @@ void GridMapRRTStarPlanner::update(NavState & nav_state)
 
     if (current_path_.poses.size() != original_size) {
       RCLCPP_DEBUG(get_node()->get_logger(),
-                         "Path trimmed: %zu -> %zu waypoints",
-                         original_size, current_path_.poses.size());
+                     "Path trimmed: %zu -> %zu waypoints",
+                     original_size, current_path_.poses.size());
     }
   }
 
@@ -871,15 +877,15 @@ void GridMapRRTStarPlanner::publish_path_markers(const nav_msgs::msg::Path & pat
     marker.type = visualization_msgs::msg::Marker::ARROW;
     marker.action = visualization_msgs::msg::Marker::ADD;
 
-        // set marker pose
+      // set marker pose
     marker.pose = pose_stamped.pose;
 
-        // set marker scale
-    marker.scale.x = 0.3;      // arrow length
-    marker.scale.y = 0.05;     // arrow thickness
+      // set marker scale
+    marker.scale.x = 0.3;    // arrow length
+    marker.scale.y = 0.05;   // arrow thickness
     marker.scale.z = 0.05;
 
-        // set marker color
+      // set marker color
     marker.color.r = 0.1f;
     marker.color.g = 0.1f;
     marker.color.b = 1.0f;
@@ -913,7 +919,8 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
     z_values[i] = input_path[i].position.z;
   }
 
-  auto compute_tangent = [&](size_t idx) -> grid_map::Position {
+  auto compute_tangent = [&](size_t idx) -> grid_map::Position
+    {
       if (idx == 0) {
         return 0.5 * (pts[1] - pts[0]);
       } else if (idx + 1 >= N) {
@@ -927,8 +934,8 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
   std::vector<double> z_tangents(N);
   for (size_t i = 0; i < N; ++i) {
     tangents[i] = compute_tangent(i);
-    z_tangents[i] = (i == 0) ? 0.5 * (z_values[1] - z_values[0]) :
-      (i + 1 >= N) ? 0.5 * (z_values[N - 1] - z_values[N - 2]) :
+    z_tangents[i] = (i == 0) ? 0.5 * (z_values[1] - z_values[0]) : (i + 1 >=
+      N) ? 0.5 * (z_values[N - 1] - z_values[N - 2]) :
       0.5 * (z_values[i + 1] - z_values[i - 1]);
   }
 
@@ -960,7 +967,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
       double t = static_cast<double>(s) / (interpolation_points_per_segment + 1);
       double t2 = t * t, t3 = t2 * t;
 
-            // Hermite interpolation
+        // Hermite interpolation
       double h00 = 2.0 * t3 - 3.0 * t2 + 1.0;
       double h10 = t3 - 2.0 * t2 + t;
       double h01 = -2.0 * t3 + 3.0 * t2;
@@ -971,7 +978,7 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
       sample.position.y = h00 * p0.y() + h10 * m0.y() + h01 * p1.y() + h11 * m1.y();
       sample.position.z = h00 * z0 + h10 * z_m0 + h01 * z1 + h11 * z_m1;
 
-            // Calculate orientation based on path direction
+        // Calculate orientation based on path direction
       double yaw = 0.0;
       if (!smoothed.empty()) {
         const auto & prev = smoothed.back().position;
@@ -980,21 +987,25 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
         if (std::hypot(dx, dy) > 1e-6) {
           yaw = std::atan2(dy, dx);
 
-                    // Smooth yaw transitions
+            // Smooth yaw transitions
           tf2::Quaternion prev_q;
           tf2::fromMsg(smoothed.back().orientation, prev_q);
           double pr, pp, prev_yaw;
           tf2::Matrix3x3(prev_q).getRPY(pr, pp, prev_yaw);
 
           double dyaw = yaw - prev_yaw;
-          while (dyaw > M_PI) {dyaw -= 2.0 * M_PI;}
-          while (dyaw < -M_PI) {dyaw += 2.0 * M_PI;}
+          while (dyaw > M_PI) {
+            dyaw -= 2.0 * M_PI;
+          }
+          while (dyaw < -M_PI) {
+            dyaw += 2.0 * M_PI;
+          }
 
           if (std::abs(dyaw) > max_yaw_step) {
             yaw = prev_yaw + (dyaw > 0 ? max_yaw_step : -max_yaw_step);
           }
         } else {
-                    // Keep previous orientation if no significant movement
+            // Keep previous orientation if no significant movement
           tf2::Quaternion prev_q;
           tf2::fromMsg(smoothed.back().orientation, prev_q);
           double pr, pp;
@@ -1006,19 +1017,19 @@ std::vector<geometry_msgs::msg::Pose> GridMapRRTStarPlanner::smooth_path(
       q.setRPY(0.0, 0.0, yaw);
       sample.orientation = tf2::toMsg(q);
 
-            // Avoid adding points too close
+        // Avoid adding points too close
       const auto & last_pos = smoothed.back().position;
       if (std::hypot(sample.position.x - last_pos.x,
-                           sample.position.y - last_pos.y) >= spacing_)
+                       sample.position.y - last_pos.y) >= spacing_)
       {
         smoothed.push_back(sample);
       }
     }
 
-        // Add the next raw waypoint with corrected orientation
+      // Add the next raw waypoint with corrected orientation
     geometry_msgs::msg::Pose next_pose = input_path[i + 1];
 
-        // Calculate orientation for the waypoint based on path direction
+      // Calculate orientation for the waypoint based on path direction
     if (!smoothed.empty()) {
       const auto & prev = smoothed.back().position;
       double dx = next_pose.position.x - prev.x;

--- a/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/KDTree.cpp
+++ b/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/KDTree.cpp
@@ -1,0 +1,107 @@
+// Copyright 2025 Intelligent Robotics Lab
+//
+// This file is part of the project Easy Navigation (EasyNav in short)
+// licensed under the GNU General Public License v3.0.
+// See <http://www.gnu.org/licenses/> for details.
+//
+// Easy Navigation program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "easynav_gridmap_rrtstar_planner/KDTree.hpp"
+#include <cmath>
+#include <algorithm>
+
+namespace easynav
+{
+
+std::unique_ptr<KDTree::KDNode> KDTree::build(
+  std::vector<std::shared_ptr<RRTNode>> & nodes,
+  int depth)
+{
+  if (nodes.empty()) {return nullptr;}
+
+    // Determine splitting axis (0 = x, 1 = y)
+  int axis = depth % 2;
+
+    // Sort nodes along the current axis
+  std::sort(nodes.begin(), nodes.end(),
+    [axis](const std::shared_ptr<RRTNode> & a, const std::shared_ptr<RRTNode> & b) {
+      return axis == 0 ? a->index.x() < b->index.x() : a->index.y() < b->index.y();
+              });
+
+    // Choose median as root of this subtree
+  int median = nodes.size() / 2;
+  auto node = std::make_unique<KDNode>(nodes[median], depth);
+
+    // Recursively build left and right subtrees
+  std::vector<std::shared_ptr<RRTNode>> left_nodes(nodes.begin(), nodes.begin() + median);
+  std::vector<std::shared_ptr<RRTNode>> right_nodes(nodes.begin() + median + 1, nodes.end());
+
+  node->left = build(left_nodes, depth + 1);
+  node->right = build(right_nodes, depth + 1);
+
+  return node;
+}
+
+void KDTree::search_radius(
+  const std::unique_ptr<KDNode> & node,
+  const grid_map::Index & target,
+  double radius_sq,
+  std::vector<std::shared_ptr<RRTNode>> & result)
+{
+  if (!node) {return;}
+
+    // Compute squared distance between node and target
+  double dx = node->rrt_node->index.x() - target.x();
+  double dy = node->rrt_node->index.y() - target.y();
+  double dist_sq = dx * dx + dy * dy;
+
+    // If within radius and not the target itself, add to result
+  if (dist_sq <= radius_sq && !(node->rrt_node->index == target).all()) {
+    result.push_back(node->rrt_node);
+  }
+
+    // Determine axis and distance along that axis
+  int axis = node->depth % 2;
+  double axis_dist = (axis == 0) ? dx : dy;
+
+    // Recursively search child nodes based on axis distance
+  if (axis_dist <= 0) {
+    search_radius(node->left, target, radius_sq, result);
+    if (axis_dist * axis_dist <= radius_sq) {
+      search_radius(node->right, target, radius_sq, result);
+    }
+  } else {
+    search_radius(node->right, target, radius_sq, result);
+    if (axis_dist * axis_dist <= radius_sq) {
+      search_radius(node->left, target, radius_sq, result);
+    }
+  }
+}
+
+void KDTree::rebuild(std::vector<std::shared_ptr<RRTNode>> & nodes)
+{
+  root = build(nodes, 0);
+}
+
+std::vector<std::shared_ptr<RRTNode>> KDTree::find_neighbors(
+  const grid_map::Index & index,
+  double radius)
+{
+  std::vector<std::shared_ptr<RRTNode>> result;
+  search_radius(root, index, radius * radius, result);
+  return result;
+}
+
+} // namespace easynav

--- a/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/KDTree.cpp
+++ b/easynav_gridmap_rrtstar_planner/src/easynav_gridmap_rrtstar_planner/KDTree.cpp
@@ -17,7 +17,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
 #include "easynav_gridmap_rrtstar_planner/KDTree.hpp"
 #include <cmath>
 #include <algorithm>
@@ -29,22 +28,25 @@ std::unique_ptr<KDTree::KDNode> KDTree::build(
   std::vector<std::shared_ptr<RRTNode>> & nodes,
   int depth)
 {
-  if (nodes.empty()) {return nullptr;}
+  if (nodes.empty()) {
+    return nullptr;
+  }
 
-    // Determine splitting axis (0 = x, 1 = y)
+  // Determine splitting axis (0 = x, 1 = y)
   int axis = depth % 2;
 
-    // Sort nodes along the current axis
+  // Sort nodes along the current axis
   std::sort(nodes.begin(), nodes.end(),
-    [axis](const std::shared_ptr<RRTNode> & a, const std::shared_ptr<RRTNode> & b) {
+    [axis](const std::shared_ptr<RRTNode> & a, const std::shared_ptr<RRTNode> & b)
+    {
       return axis == 0 ? a->index.x() < b->index.x() : a->index.y() < b->index.y();
-              });
+    });
 
-    // Choose median as root of this subtree
+  // Choose median as root of this subtree
   int median = nodes.size() / 2;
   auto node = std::make_unique<KDNode>(nodes[median], depth);
 
-    // Recursively build left and right subtrees
+  // Recursively build left and right subtrees
   std::vector<std::shared_ptr<RRTNode>> left_nodes(nodes.begin(), nodes.begin() + median);
   std::vector<std::shared_ptr<RRTNode>> right_nodes(nodes.begin() + median + 1, nodes.end());
 
@@ -60,23 +62,25 @@ void KDTree::search_radius(
   double radius_sq,
   std::vector<std::shared_ptr<RRTNode>> & result)
 {
-  if (!node) {return;}
+  if (!node) {
+    return;
+  }
 
-    // Compute squared distance between node and target
+  // Compute squared distance between node and target
   double dx = node->rrt_node->index.x() - target.x();
   double dy = node->rrt_node->index.y() - target.y();
   double dist_sq = dx * dx + dy * dy;
 
-    // If within radius and not the target itself, add to result
+  // If within radius and not the target itself, add to result
   if (dist_sq <= radius_sq && !(node->rrt_node->index == target).all()) {
     result.push_back(node->rrt_node);
   }
 
-    // Determine axis and distance along that axis
+  // Determine axis and distance along that axis
   int axis = node->depth % 2;
   double axis_dist = (axis == 0) ? dx : dy;
 
-    // Recursively search child nodes based on axis distance
+  // Recursively search child nodes based on axis distance
   if (axis_dist <= 0) {
     search_radius(node->left, target, radius_sq, result);
     if (axis_dist * axis_dist <= radius_sq) {


### PR DESCRIPTION
Hi! 

I've added an alternative planner to this stack. It is an RRT* for gridmaps using slope-aware traversal cost, goal biasing, and KD-Tree acceleration for efficient searches.

The planner also includes Catmull–Rom spline-based path smoothing with minimal spacing enforcement to reduce redundant waypoints.

A demonstration video shows the planner in action using the EasyNav simple controller and LiDAR-SLAM for localization.

https://github.com/user-attachments/assets/fb9906b2-bb6f-4319-b4b2-8315dd416d80

Any feedback or suggestions are more than welcome! :)